### PR TITLE
#2500 Fixed FunctionalExchange queries on FIP and FOP

### DIFF
--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/Pin_incomingDataflows.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/Pin_incomingDataflows.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,38 +16,33 @@ package org.polarsys.capella.core.semantic.queries.basic.queries;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.polarsys.capella.core.data.fa.FunctionInputPort;
-import org.polarsys.capella.core.data.fa.FunctionOutputPort;
 import org.polarsys.capella.common.helpers.query.IQuery;
+import org.polarsys.capella.core.data.fa.FunctionInputPort;
 
 /**
  *
  */
 public class Pin_incomingDataflows implements IQuery {
 
-	/**
-	 * 
-	 */
-	public Pin_incomingDataflows() {
+  /**
+   * 
+   */
+  public Pin_incomingDataflows() {
     // do nothing
-	}
+  }
 
-	/** 
-	 * 
-	 * current.exchanges
-	 * 
-	 * @see org.polarsys.capella.common.helpers.query.IQuery#compute(java.lang.Object)
-	 */
-	public List<Object> compute(Object object) {
-		List<Object> result = new ArrayList<Object>();
-		if (object instanceof FunctionInputPort) {
-			FunctionInputPort fp = (FunctionInputPort) object;
-			result.addAll(fp.getIncoming());
-		}
-		else if (object instanceof FunctionOutputPort) {
-			FunctionOutputPort fp = (FunctionOutputPort) object;
-			result.addAll(fp.getOutgoing());
-		}
-		return result;
-	}
+  /**
+   * 
+   * current.exchanges
+   * 
+   * @see org.polarsys.capella.common.helpers.query.IQuery#compute(java.lang.Object)
+   */
+  public List<Object> compute(Object object) {
+    List<Object> result = new ArrayList<Object>();
+    if (object instanceof FunctionInputPort) {
+      FunctionInputPort fp = (FunctionInputPort) object;
+      result.addAll(fp.getIncoming());
+    }
+    return result;
+  }
 }

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/Pin_outgoingDataflows.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/Pin_outgoingDataflows.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,38 +16,33 @@ package org.polarsys.capella.core.semantic.queries.basic.queries;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.polarsys.capella.core.data.fa.FunctionInputPort;
-import org.polarsys.capella.core.data.fa.FunctionOutputPort;
 import org.polarsys.capella.common.helpers.query.IQuery;
+import org.polarsys.capella.core.data.fa.FunctionOutputPort;
 
 /**
  *
  */
 public class Pin_outgoingDataflows implements IQuery {
 
-	/**
-	 * 
-	 */
-	public Pin_outgoingDataflows() {
+  /**
+   * 
+   */
+  public Pin_outgoingDataflows() {
     // do nothing
-	}
+  }
 
-	/** 
-	 * 
-	 * current.exchanges
-	 * 
-	 * @see org.polarsys.capella.common.helpers.query.IQuery#compute(java.lang.Object)
-	 */
-	public List<Object> compute(Object object) {
-		List<Object> result = new ArrayList<Object>();
-		if (object instanceof FunctionInputPort) {
-			FunctionInputPort fp = (FunctionInputPort) object;
-			result.addAll(fp.getIncoming());
-		}
-		else if (object instanceof FunctionOutputPort) {
-			FunctionOutputPort fp = (FunctionOutputPort) object;
-			result.addAll(fp.getOutgoing());
-		}
-		return result;
-	}
+  /**
+   * 
+   * current.exchanges
+   * 
+   * @see org.polarsys.capella.common.helpers.query.IQuery#compute(java.lang.Object)
+   */
+  public List<Object> compute(Object object) {
+    List<Object> result = new ArrayList<Object>();
+    if (object instanceof FunctionOutputPort) {
+      FunctionOutputPort fp = (FunctionOutputPort) object;
+      result.addAll(fp.getOutgoing());
+    }
+    return result;
+  }
 }

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/model/SemanticQueries.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/model/SemanticQueries.java
@@ -360,6 +360,9 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String PA__PL2 = "251270d7-8c45-489e-b283-a504fc9d06a2";
   public static final String PA__PL3 = "f9dad582-b443-4dc5-83f0-b0800706fb39";
   public static final String PA__PL4 = "8b0f14b1-9b08-4ee8-9771-eabb9d99aa8b";
+  public static final String PA__PF1_FOP1 = "fdd9e69e-179c-43f7-a9f8-0e52b74a6fae";
+  public static final String PA__PF2_FIP1 = "a7f4d482-bb03-4302-aa03-b22c0506fcc8";
+  public static final String PA__FE1 = "6fd8df09-4eec-4b53-a6cd-38e5522c453a";
   public static final String EPBS = "1729bd4c-a4d2-48c2-ac5e-cf84172ae391";
   public static final String EPBS__CAPABILITIES = "51981734-92ce-4076-8ef2-702a1097fc2b";
   public static final String EPBS__CAPABILITIES__CAPABILITY_2 = "94e2e370-1828-4bf8-ad0b-80d8e6e22898";

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/FunctionInputPort_IncomingFunctionalExchanges.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/FunctionInputPort_IncomingFunctionalExchanges.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.semantic.queries.ju.testcases;
+
+import org.polarsys.capella.test.semantic.queries.ju.model.SemanticQueries;
+
+/**
+ * Test for <i>ExchangeItem realized EI</i> query
+ */
+public class FunctionInputPort_IncomingFunctionalExchanges extends SemanticQueries {
+  /**
+   * The Query under test.
+   */
+  String QUERY = "org.polarsys.capella.core.semantic.queries.Pin_incomingDataflows";
+
+  /**
+   * @return the query category identifier.
+   */
+  @Override
+  protected String getQueryCategoryIdentifier() {
+    return QUERY;
+  }
+
+  /**
+   * Test method.
+   */
+  @Override
+  public void test() throws Exception {
+    testQuery(PA__PF1_FOP1);
+    testQuery(PA__PF2_FIP1, PA__FE1);
+  }
+
+}

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/FunctionOutputPort_OutgoingFunctionalExchanges.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/FunctionOutputPort_OutgoingFunctionalExchanges.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.semantic.queries.ju.testcases;
+
+import org.polarsys.capella.test.semantic.queries.ju.model.SemanticQueries;
+
+/**
+ * Test for <i>ExchangeItem realized EI</i> query
+ */
+public class FunctionOutputPort_OutgoingFunctionalExchanges extends SemanticQueries {
+  /**
+   * The Query under test.
+   */
+  String QUERY = "org.polarsys.capella.core.semantic.queries.Pin_outgoingDataflows";
+
+  /**
+   * @return the query category identifier.
+   */
+  @Override
+  protected String getQueryCategoryIdentifier() {
+    return QUERY;
+  }
+
+  /**
+   * Test method.
+   */
+  @Override
+  public void test() throws Exception {
+    testQuery(PA__PF1_FOP1, PA__FE1);
+    testQuery(PA__PF2_FIP1);
+  }
+
+}

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testsuites/SemanticQueriesTestSuite.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testsuites/SemanticQueriesTestSuite.java
@@ -34,7 +34,7 @@ public class SemanticQueriesTestSuite extends BasicTestSuite {
     tests.add(new UniqueIDInPluginsTest());
     tests.add(new AvailableForTypeClassExistTest());
     tests.add(new AbstractFunction_mother_activity_allocation());
-    tests.add(new AbstractFunction_mother_function_allocation());   
+    tests.add(new AbstractFunction_mother_function_allocation());
     tests.add(new CapellaElement_applied_property_value_groups());
     tests.add(new CapellaElement_applied_property_values());
     tests.add(new PropertyValue_applying_valued_element());
@@ -177,11 +177,13 @@ public class SemanticQueriesTestSuite extends BasicTestSuite {
     tests.add(new PhysicalPortIncomingPhysicalLinks());
     tests.add(new FunctionalExchangeConnectedOperationalActivities());
     tests.add(new FunctionalExchangeConnectedFunctions());
+    tests.add(new FunctionInputPort_IncomingFunctionalExchanges());
+    tests.add(new FunctionOutputPort_OutgoingFunctionalExchanges());
     tests.add(new EntityOutgoingCommunicationMeans());
     tests.add(new EntityIncomingCommunicationMeans());
     tests.add(new PhysicalPathInvolvedPhysicalLinks());
     tests.add(new PhysicalPathInvolvedComponents());
-    
+
     return tests;
   }
 


### PR DESCRIPTION
Semantic Browser Queries on FunctionInputPort and FunctionOutputPort displayed FunctionalExchanges twice, in the outgoing and in the incoming FE

Change-Id: I029e87c4b0edb226d7003b8fb80d69a49792d94c
Signed-off-by: Erwann Traisnel <erwann.traisnel@obeo.fr>