### PR TITLE
#2829 Add robustness when target of FC/PP/Scenario reference is null

### DIFF
--- a/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/helpers/FunctionalChainExt.java
+++ b/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/helpers/FunctionalChainExt.java
@@ -1120,19 +1120,25 @@ public class FunctionalChainExt {
 
   public static Collection<ControlNode> getFlatControlNodes(FunctionalChain functionalChain) {
     List<ControlNode> ownedSequenceNodes = new ArrayList<>();
-    ownedSequenceNodes.addAll(functionalChain.getOwnedSequenceNodes());
-    functionalChain.getOwnedFunctionalChainInvolvements().stream().filter(FunctionalChainReference.class::isInstance)
-        .map(FunctionalChainReference.class::cast).map(FunctionalChainReference::getInvolved)
-        .map(FunctionalChain.class::cast).distinct().forEach(fc -> ownedSequenceNodes.addAll(getFlatControlNodes(fc)));
+    if (functionalChain != null) {
+      ownedSequenceNodes.addAll(functionalChain.getOwnedSequenceNodes());
+      functionalChain.getOwnedFunctionalChainInvolvements().stream().filter(FunctionalChainReference.class::isInstance)
+          .map(FunctionalChainReference.class::cast).map(FunctionalChainReference::getInvolved)
+          .map(FunctionalChain.class::cast).distinct()
+          .forEach(fc -> ownedSequenceNodes.addAll(getFlatControlNodes(fc)));
+    }
     return ownedSequenceNodes;
   }
 
   public static Collection<SequenceLink> getFlatSequenceLinks(FunctionalChain functionalChain) {
     List<SequenceLink> ownedSequenceLinks = new ArrayList<>();
-    ownedSequenceLinks.addAll(functionalChain.getOwnedSequenceLinks());
-    functionalChain.getOwnedFunctionalChainInvolvements().stream().filter(FunctionalChainReference.class::isInstance)
-        .map(FunctionalChainReference.class::cast).map(FunctionalChainReference::getInvolved)
-        .map(FunctionalChain.class::cast).distinct().forEach(fc -> ownedSequenceLinks.addAll(getFlatSequenceLinks(fc)));
+    if (functionalChain != null) {
+      ownedSequenceLinks.addAll(functionalChain.getOwnedSequenceLinks());
+      functionalChain.getOwnedFunctionalChainInvolvements().stream().filter(FunctionalChainReference.class::isInstance)
+          .map(FunctionalChainReference.class::cast).map(FunctionalChainReference::getInvolved)
+          .map(FunctionalChain.class::cast).distinct()
+          .forEach(fc -> ownedSequenceLinks.addAll(getFlatSequenceLinks(fc)));
+    }
     return ownedSequenceLinks;
   }
 }

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/actions/providers/DynamicOpenRepresentationContributionItem.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/actions/providers/DynamicOpenRepresentationContributionItem.java
@@ -119,53 +119,60 @@ public class DynamicOpenRepresentationContributionItem extends CompoundContribut
 
       // create scenarios from capabilities
       if (hasDerivedOpenRepresentationContribution(firstSelectedEObject)) {
-          addDerivedOpenRepresentationActions(firstSelectedEObject, menu, currentSession,
-            selectedViewpoints);
+        addDerivedOpenRepresentationActions(firstSelectedEObject, menu, currentSession, selectedViewpoints);
       }
     }
-    
+
     private boolean hasDerivedOpenRepresentationContribution(EObject semanticElement) {
-        return (semanticElement instanceof AbstractCapability) || 
-                (semanticElement instanceof FunctionalChainReference) || 
-                (semanticElement instanceof PhysicalPathReference) ||
-                (semanticElement instanceof InteractionUse);
-    }
-    
-    private void addDerivedOpenRepresentationActions(EObject semanticElement, IMenuManager menu, Session currentSession, Collection<Viewpoint> selectedViewpoints) {
-        for (Viewpoint vp : selectedViewpoints) {
-            for (RepresentationDescription representationDescription : vp.getOwnedRepresentations()) {
-                Collection<DRepresentationDescriptor> descriptors = DialectManager.INSTANCE.getRepresentationDescriptors(representationDescription, currentSession);
-                if (descriptors != null) {
-                    createOpenRepresentationAction(semanticElement, menu, currentSession, representationDescription, descriptors);
-                }
-            }
-        }
+      return (semanticElement instanceof AbstractCapability) || (semanticElement instanceof FunctionalChainReference)
+          || (semanticElement instanceof PhysicalPathReference) || (semanticElement instanceof InteractionUse);
     }
 
-    private void createOpenRepresentationAction(EObject semanticElement, IMenuManager menu, Session currentSession, RepresentationDescription representationDescription,
-            Collection<DRepresentationDescriptor> descriptors) {
-        Collection<DRepresentationDescriptor> ownedDescriptors = new ArrayList<>();
-        List<EObject> derivedElements = new ArrayList<>();
-        if (semanticElement instanceof AbstractCapability && representationDescription instanceof SequenceDiagramDescription) {
-            derivedElements.addAll(((AbstractCapability) semanticElement).getOwnedScenarios());
-        } else if ((semanticElement instanceof FunctionalChainReference || semanticElement instanceof PhysicalPathReference) && representationDescription instanceof DiagramDescription) {
-            if (semanticElement instanceof FunctionalChainReference) {
-                derivedElements.add(((FunctionalChainReference) semanticElement).getReferencedFunctionalChain());
-            } else if (semanticElement instanceof PhysicalPathReference) {
-                derivedElements.add(((PhysicalPathReference) semanticElement).getReferencedPhysicalPath());
-            }
-        } else if (semanticElement instanceof InteractionUse && representationDescription instanceof SequenceDiagramDescription) {
-            derivedElements.add(((InteractionUse)semanticElement).getReferencedScenario());
+    private void addDerivedOpenRepresentationActions(EObject semanticElement, IMenuManager menu, Session currentSession,
+        Collection<Viewpoint> selectedViewpoints) {
+      for (Viewpoint vp : selectedViewpoints) {
+        for (RepresentationDescription representationDescription : vp.getOwnedRepresentations()) {
+          Collection<DRepresentationDescriptor> descriptors = DialectManager.INSTANCE
+              .getRepresentationDescriptors(representationDescription, currentSession);
+          if (descriptors != null) {
+            createOpenRepresentationAction(semanticElement, menu, currentSession, representationDescription,
+                descriptors);
+          }
         }
-        for (EObject object : derivedElements) {
-            Collection<DRepresentationDescriptor> repDescScenario = DialectManager.INSTANCE.getRepresentationDescriptors(object, currentSession);
-            ownedDescriptors.addAll(repDescScenario);
-        }
-        descriptors.retainAll(ownedDescriptors);
+      }
+    }
 
-        for (DRepresentationDescriptor descriptor : descriptors) {
-            menu.add(new OpenRepresentationsAction(descriptor));
+    private void createOpenRepresentationAction(EObject semanticElement, IMenuManager menu, Session currentSession,
+        RepresentationDescription representationDescription, Collection<DRepresentationDescriptor> descriptors) {
+      Collection<DRepresentationDescriptor> ownedDescriptors = new ArrayList<>();
+      List<EObject> derivedElements = new ArrayList<>();
+      EObject targetSemanticElement = null;
+      if (representationDescription instanceof SequenceDiagramDescription) {
+        if (semanticElement instanceof AbstractCapability) {
+          derivedElements.addAll(((AbstractCapability) semanticElement).getOwnedScenarios());
+        } else if (semanticElement instanceof InteractionUse) {
+          targetSemanticElement = ((InteractionUse) semanticElement).getReferencedScenario();
         }
+      } else if (representationDescription instanceof DiagramDescription) {
+        if (semanticElement instanceof FunctionalChainReference) {
+          targetSemanticElement = ((FunctionalChainReference) semanticElement).getReferencedFunctionalChain();
+        } else if (semanticElement instanceof PhysicalPathReference) {
+          targetSemanticElement = ((PhysicalPathReference) semanticElement).getReferencedPhysicalPath();
+        }
+      }
+      if (targetSemanticElement != null) {
+        derivedElements.add(targetSemanticElement);
+      }
+      for (EObject object : derivedElements) {
+        Collection<DRepresentationDescriptor> repDescScenario = DialectManager.INSTANCE
+            .getRepresentationDescriptors(object, currentSession);
+        ownedDescriptors.addAll(repDescScenario);
+      }
+      descriptors.retainAll(ownedDescriptors);
+
+      for (DRepresentationDescriptor descriptor : descriptors) {
+        menu.add(new OpenRepresentationsAction(descriptor));
+      }
     }
   }
 

--- a/core/plugins/org.polarsys.capella.core.preferences/src/org/polarsys/capella/core/commands/preferences/ui/sirius/DoubleClickBehaviourUtil.java
+++ b/core/plugins/org.polarsys.capella.core.preferences/src/org/polarsys/capella/core/commands/preferences/ui/sirius/DoubleClickBehaviourUtil.java
@@ -39,7 +39,9 @@ public class DoubleClickBehaviourUtil {
   public boolean shouldOpenRelatedDiagramsOnDoubleClick(EObject source) {
     boolean navigateOnDoubleClick = Activator.getDefault().getPreferenceStore()
         .getBoolean(CapellaDiagramPreferences.PREF_DISPLAY_NAVIGATE_ON_DOUBLE_CLICK);
-    return navigateOnDoubleClick && (source instanceof FunctionalChain || source instanceof FunctionalChainReference
+    boolean hasTargetSemanticElement = getTargetSemanticElement(source) != null;
+    return navigateOnDoubleClick && hasTargetSemanticElement && (source instanceof FunctionalChain
+        || source instanceof FunctionalChainReference
         || source instanceof PhysicalPath || source instanceof PhysicalPathReference || source instanceof InteractionUse
         || source instanceof Scenario);
   }

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/FunctionalChainInvolvementFunctions.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/FunctionalChainInvolvementFunctions.java
@@ -47,6 +47,6 @@ public class FunctionalChainInvolvementFunctions implements IQuery {
   }
 
   protected boolean isValidInstanceOf(FunctionalChain object) {
-    return !(object instanceof OperationalProcess);
+    return !(object == null || object instanceof OperationalProcess);
   }
 }

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/Scenario_RelatedFunctions.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/Scenario_RelatedFunctions.java
@@ -26,29 +26,30 @@ import org.polarsys.capella.core.data.oa.OperationalActivity;
 
 public class Scenario_RelatedFunctions implements IQuery {
 
-    public Scenario_RelatedFunctions() {
-        // Do nothing
-    }
+  public Scenario_RelatedFunctions() {
+    // Do nothing
+  }
 
-    /**
-     * @see org.polarsys.capella.common.helpers.query.IQuery#compute(java.lang.Object)
-     */
-    public List<Object> compute(Object object) {
-        List<Object> result = new ArrayList<>();
-        if (object instanceof Scenario) {
-            Scenario af = (Scenario) object;
-            for (TimeLapse element : af.getOwnedTimeLapses().stream().filter(StateFragment.class::isInstance).collect(Collectors.toList())) {
-                StateFragment fragment = (StateFragment) element;
-                AbstractFunction absFunction = fragment.getRelatedAbstractFunction();
-                if (null != absFunction && isValidInstanceOf(absFunction)) {
-                    result.add(absFunction);
-                }
-            }
+  /**
+   * @see org.polarsys.capella.common.helpers.query.IQuery#compute(java.lang.Object)
+   */
+  public List<Object> compute(Object object) {
+    List<Object> result = new ArrayList<>();
+    if (object instanceof Scenario) {
+      Scenario af = (Scenario) object;
+      for (TimeLapse element : af.getOwnedTimeLapses().stream().filter(StateFragment.class::isInstance)
+          .collect(Collectors.toList())) {
+        StateFragment fragment = (StateFragment) element;
+        AbstractFunction absFunction = fragment.getRelatedAbstractFunction();
+        if (isValidInstanceOf(absFunction)) {
+          result.add(absFunction);
         }
-        return result;
+      }
     }
+    return result;
+  }
 
-    protected boolean isValidInstanceOf(Object absFunction) {
-        return !(absFunction instanceof OperationalActivity);
-    }
+  protected boolean isValidInstanceOf(Object absFunction) {
+    return !(absFunction == null || absFunction instanceof OperationalActivity);
+  }
 }

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/policies/OpenRelatedDiagramEditPolicy.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/policies/OpenRelatedDiagramEditPolicy.java
@@ -42,7 +42,6 @@ import org.eclipse.sirius.diagram.ui.tools.api.command.GMFCommandWrapper;
 import org.eclipse.sirius.tools.api.interpreter.InterpreterUtil;
 import org.eclipse.sirius.ui.tools.internal.editor.NavigateToCommand;
 import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
-import org.eclipse.sirius.viewpoint.DSemanticDecorator;
 import org.eclipse.sirius.viewpoint.description.RepresentationDescription;
 import org.eclipse.sirius.viewpoint.description.Viewpoint;
 import org.eclipse.swt.widgets.Display;
@@ -70,13 +69,15 @@ public class OpenRelatedDiagramEditPolicy extends OpenDiagramEditPolicy {
         View view = editPart.getNotationView();
         if (view != null) {
           EObject element = ViewUtil.resolveSemanticElement(view);
-          EObject targetSemanticElement = null;
-          if (element instanceof DSemanticDecorator) {
-            DSemanticDecorator container = (DSemanticDecorator) element;
-            targetSemanticElement = container.getTarget();
-          }
-          if (!((DDiagramElement) element).getParentDiagram().isIsInShowingMode() && targetSemanticElement != null
-              && DoubleClickBehaviourUtil.INSTANCE.shouldOpenRelatedDiagramsOnDoubleClick(targetSemanticElement)) {
+          if (element instanceof DDiagramElement) {
+            DDiagramElement container = (DDiagramElement) element;
+            EObject targetSemanticElement = container.getTarget();
+
+            if (container.getParentDiagram().isIsInShowingMode() || targetSemanticElement == null
+                || !DoubleClickBehaviourUtil.INSTANCE.shouldOpenRelatedDiagramsOnDoubleClick(targetSemanticElement)) {
+              return null;
+            }
+
             targetSemanticElement = DoubleClickBehaviourUtil.INSTANCE.getTargetSemanticElement(targetSemanticElement);
             Session session = SessionManager.INSTANCE.getSession(element);
             Collection<DRepresentationDescriptor> representations = RepresentationHelper
@@ -117,8 +118,8 @@ public class OpenRelatedDiagramEditPolicy extends OpenDiagramEditPolicy {
                         navCommand.execute();
                       }
                     };
-                    return new ICommandProxy(
-                        new GMFCommandWrapper(session.getTransactionalEditingDomain(), createRepresentationCommand));
+                    return new ICommandProxy(new GMFCommandWrapper(session.getTransactionalEditingDomain(),
+                        createRepresentationCommand));
 
                   }
                 } else {

--- a/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/wizards/CapellaWizardDialog.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/wizards/CapellaWizardDialog.java
@@ -19,7 +19,6 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
-
 import org.polarsys.capella.common.ui.toolkit.dialogs.IDialog;
 
 /**
@@ -69,5 +68,11 @@ public class CapellaWizardDialog extends WizardDialog implements IDialog {
   public void updateButtons() {
     boolean canFinish = getWizard().canFinish();
     _finishButton.setEnabled(canFinish);
+  }
+
+  @Override
+  public boolean close() {
+    _finishButton.dispose();
+    return super.close();
   }
 }

--- a/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/wizards/EditCapellaCustomPropertyWizardPage.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/wizards/EditCapellaCustomPropertyWizardPage.java
@@ -170,19 +170,19 @@ public class EditCapellaCustomPropertyWizardPage extends WizardPage implements I
           ISectionDescriptor sectionDescriptor = (ISectionDescriptor) sd;
           ISection section = sectionDescriptor.getSectionClass();
           if (section != null) {
-              Composite sectionComposite = new Composite(tabItemContent, SWT.NONE);
-              sectionComposite.setLayout(new FillLayout());
-              int style = (section.shouldUseExtraSpace()) ? GridData.FILL_BOTH : GridData.FILL_HORIZONTAL;
-              GridData data = new GridData(style);
-              data.heightHint = section.getMinimumHeight();
-              sectionComposite.setLayoutData(data);
-              section.createControls(sectionComposite, null);
-              section.setInput(part, new StructuredSelection(object));
-              tabItem.setData(section);
-              sections.add(section);
-            }
+            Composite sectionComposite = new Composite(tabItemContent, SWT.NONE);
+            sectionComposite.setLayout(new FillLayout());
+            int style = (section.shouldUseExtraSpace()) ? GridData.FILL_BOTH : GridData.FILL_HORIZONTAL;
+            GridData data = new GridData(style);
+            data.heightHint = section.getMinimumHeight();
+            sectionComposite.setLayoutData(data);
+            section.createControls(sectionComposite, null);
+            section.setInput(part, new StructuredSelection(object));
+            tabItem.setData(section);
+            sections.add(section);
           }
         }
+      }
 
     }
 
@@ -247,7 +247,7 @@ public class EditCapellaCustomPropertyWizardPage extends WizardPage implements I
 
       protected String generateHTMLLink(EClass eclass) {
         return "/org.polarsys.capella.core.doc.user/html/editors/" + //$NON-NLS-1$
-        eclass.getEPackage().getName() + ICommonConstants.SLASH_CHARACTER + eclass.getName()
+            eclass.getEPackage().getName() + ICommonConstants.SLASH_CHARACTER + eclass.getName()
             + ICommonConstants.POINT_CHARACTER + "html"; //$NON-NLS-1$
       }
     };
@@ -280,6 +280,7 @@ public class EditCapellaCustomPropertyWizardPage extends WizardPage implements I
       sections = null;
     }
 
+    getImage().dispose();
     TabbedPropertyRegistryFactory.getInstance().disposeRegistry(this);
 
   }
@@ -307,5 +308,5 @@ public class EditCapellaCustomPropertyWizardPage extends WizardPage implements I
   public String getContributorId() {
     return CapellaUIPropertiesPlugin.PROPERTIES_CONTRIBUTOR;
   }
-  
+
 }

--- a/core/plugins/org.polarsys.capella.core.ui.semantic.browser.sirius/src/org/polarsys/capella/core/ui/semantic/browser/sirius/handlers/NavigationSemanticBrowserDoubleClickHandler.java
+++ b/core/plugins/org.polarsys.capella.core.ui.semantic.browser.sirius/src/org/polarsys/capella/core/ui/semantic/browser/sirius/handlers/NavigationSemanticBrowserDoubleClickHandler.java
@@ -12,87 +12,91 @@ import org.polarsys.capella.core.ui.semantic.browser.handler.DefaultSemanticBrow
 import org.polarsys.capella.core.ui.semantic.browser.sirius.actions.DiagramOpenAction;
 import org.polarsys.capella.core.ui.semantic.browser.view.SemanticBrowserView;
 
-public class NavigationSemanticBrowserDoubleClickHandler extends DefaultSemanticBrowserDoubleClickHandler{
-  
+public class NavigationSemanticBrowserDoubleClickHandler extends DefaultSemanticBrowserDoubleClickHandler {
+
   @Override
   public void handle(SemanticBrowserView view, DoubleClickEvent event, Object selectedElement) {
-    //Get selection of currently selected viewer
-    //Right now this is the only way to get the selection from Referenced or Referencing viewer
+    // Get selection of currently selected viewer
+    // Right now this is the only way to get the selection from Referenced or Referencing viewer
     IStructuredSelection selection = (IStructuredSelection) view.getSite().getSelectionProvider().getSelection();
 
-    if (!selection.isEmpty()) {      
-      if(selection.size() == 1 ){
-        if(isCtrlKeyPressed()) { 
-          //If CTRL is pressed on double-click on a single element, it shall be put as the current element
+    if (!selection.isEmpty()) {
+      if (selection.size() == 1) {
+        if (isCtrlKeyPressed()) {
+          // If CTRL is pressed on double-click on a single element, it shall be put as the current element
           super.handle(view, event, selectedElement);
         } else {
-          //If it wasn't pressed, run navigation action
+          // If it wasn't pressed, run navigation action
           runAction(view, event, selectedElement);
-        }       
-      }else{
-        //If multiple elements in the selection, run action on each of them
-        for(Object element : selection.toList()) {
-          runAction(view, event, element);          
+        }
+      } else {
+        // If multiple elements in the selection, run action on each of them
+        for (Object element : selection.toList()) {
+          runAction(view, event, element);
         }
       }
     }
   }
-  
+
   protected void runAction(SemanticBrowserView view, DoubleClickEvent event, Object selectedElement) {
     if (selectedElement instanceof EObjectWrapper) {
       selectedElement = ((EObjectWrapper) selectedElement).getElement();
-    }   
-    if(! (selectedElement instanceof EObject)) {
-      //Not handled
-      return; 
     }
-    
+    if (!(selectedElement instanceof EObject)) {
+      // Not handled
+      return;
+    }
+
     EObject elementAsEObject = (EObject) selectedElement;
-    if(shouldOpenDiagram(elementAsEObject)) {
-      openDiagram(view, (DRepresentationDescriptor)elementAsEObject);
-    }else {
-      if(shouldNavigate(elementAsEObject)) {
+    if (shouldOpenDiagram(elementAsEObject)) {
+      openDiagram(view, (DRepresentationDescriptor) elementAsEObject);
+    } else {
+      if (shouldNavigate(elementAsEObject)) {
         openRelatedDiagrams(elementAsEObject);
-      }else{ 
+      } else {
         // Should open wizard
         super.runAction(view, event, elementAsEObject);
-      }      
+      }
     }
-                 
-    
+
   }
-  
+
   /**
    * Returns true if double-click on selectedElement should execute the navigation action
+   * 
    * @param selectedElement
    * @return
    */
-  public boolean shouldNavigate(EObject selectedElement) {      
-    return DoubleClickBehaviourUtil.INSTANCE.shouldOpenRelatedDiagramsOnDoubleClick(selectedElement);
+  public boolean shouldNavigate(EObject selectedElement) {
+    return selectedElement != null
+        && DoubleClickBehaviourUtil.INSTANCE.shouldOpenRelatedDiagramsOnDoubleClick(selectedElement);
   }
-  
+
   /**
    * Returns true if double-click on selectedElement should open the properties wizard
+   * 
    * @param selectedElement
    * @return
    */
   public boolean shouldOpenPropertyWizard(EObject selectedElement) {
-    if(shouldOpenDiagram(selectedElement))
+    if (shouldOpenDiagram(selectedElement))
       return false;
-   return !shouldNavigate(selectedElement);  
+    return !shouldNavigate(selectedElement);
   }
-  
+
   /**
    * Returns true if double-click on selectedElement should open the diagram
+   * 
    * @param selectedElement
    * @return
    */
   public boolean shouldOpenDiagram(EObject selectedElement) {
     return selectedElement instanceof DRepresentationDescriptor;
   }
-  
+
   /**
    * Open diagram of given diagram descriptor
+   * 
    * @param diagramToOpen
    */
   protected void openDiagram(SemanticBrowserView view, DRepresentationDescriptor diagramToOpen) {
@@ -104,12 +108,13 @@ public class NavigationSemanticBrowserDoubleClickHandler extends DefaultSemantic
   }
 
   /**
-   * Run the OpenRelatedDiagramAction on selected element 
+   * Run the OpenRelatedDiagramAction on selected element
+   * 
    * @param selectedElement
    */
-  protected void openRelatedDiagrams(EObject selectedElement) {   
+  protected void openRelatedDiagrams(EObject selectedElement) {
     OpenRelatedDiagramAction action = new OpenRelatedDiagramAction(selectedElement);
-    action.run();       
+    action.run();
   }
 
 }

--- a/tests/plugins/org.polarsys.capella.test.platform.ju/build.properties
+++ b/tests/plugins/org.polarsys.capella.test.platform.ju/build.properties
@@ -15,4 +15,5 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                about.html,\
-               plugin.properties
+               plugin.properties,\
+               model/

--- a/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/.project
+++ b/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>TestNavigationDoubleClick</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
+	</natures>
+</projectDescription>

--- a/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/.settings/org.eclipse.core.resources.prefs
+++ b/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/TestNavigationDoubleClick.afm
+++ b/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/TestNavigationDoubleClick.afm
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_gsWC4Nr8Ee6g1ac8T6chTw">
+  <viewpointReferences id="_gtBYUNr8Ee6g1ac8T6chTw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.0"/>
+</metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/TestNavigationDoubleClick.aird
+++ b/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/TestNavigationDoubleClick.aird
@@ -1,0 +1,461 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:concern="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:description_2="http://www.eclipse.org/sirius/diagram/sequence/description/2.0.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:filter="http://www.eclipse.org/sirius/diagram/description/filter/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0" xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/7.0.0" xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/7.0.0" xmlns:org.polarsys.capella.core.data.interaction="http://www.polarsys.org/capella/core/interaction/7.0.0" xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/7.0.0" xmlns:sequence="http://www.eclipse.org/sirius/diagram/sequence/2.0.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/concern http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/sequence/description/2.0.0 http://www.eclipse.org/sirius/diagram/sequence/2.0.0#//description http://www.eclipse.org/sirius/diagram/description/filter/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/filter http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_gsZGMNr8Ee6g1ac8T6chTw" selectedViews="_gty0YNr8Ee6g1ac8T6chTw _gvYIwNr8Ee6g1ac8T6chTw _g2h5oNr8Ee6g1ac8T6chTw _g674gNr8Ee6g1ac8T6chTw _g7cO0Nr8Ee6g1ac8T6chTw _g9A8INr8Ee6g1ac8T6chTw _g98JMNr8Ee6g1ac8T6chTw" version="15.2.0.202303281325">
+    <semanticResources>TestNavigationDoubleClick.afm</semanticResources>
+    <semanticResources>TestNavigationDoubleClick.capella</semanticResources>
+    <ownedViews xmi:type="viewpoint:DView" uid="_gty0YNr8Ee6g1ac8T6chTw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_gvYIwNr8Ee6g1ac8T6chTw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_kNnKMNr8Ee6g1ac8T6chTw" name="[OPD] OperationalProcess 1" repPath="#_kNlVANr8Ee6g1ac8T6chTw" changeId="1709648879206">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="TestNavigationDoubleClick.capella#03df8c34-349f-4b7f-b8d4-8ef8a1047bc6"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_l3pqINr8Ee6g1ac8T6chTw" name="[OPD] OperationalProcess 2" repPath="#_l3pDENr8Ee6g1ac8T6chTw" changeId="1709648910166">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="TestNavigationDoubleClick.capella#46631d60-ec95-42f6-b139-f150db02978a"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_g2h5oNr8Ee6g1ac8T6chTw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_0ofBMNr8Ee6g1ac8T6chTw" name="[SFCD] FunctionalChain 1" repPath="#_0oeaINr8Ee6g1ac8T6chTw" changeId="1709648989385">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="TestNavigationDoubleClick.capella#fa753755-2732-4c2f-8877-89152e3e34f7"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_20T_ktr8Ee6g1ac8T6chTw" name="[SFCD] FunctionalChain 2" repPath="#_20T_kNr8Ee6g1ac8T6chTw" changeId="1709649017461">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="TestNavigationDoubleClick.capella#57c6baa8-e679-4612-81d0-466aae821398"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_AsV0oNr9Ee6g1ac8T6chTw" name="[ES] Scenario 2" repPath="#_AsSxUNr9Ee6g1ac8T6chTw" changeId="1709649114884">
+        <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']"/>
+        <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="TestNavigationDoubleClick.capella#036e128b-414b-42a9-aa2e-e04f381aaa0e"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_Duy5ANr9Ee6g1ac8T6chTw" name="[ES] Scenario 1" repPath="#_Duxq4Nr9Ee6g1ac8T6chTw" changeId="1709649091520">
+        <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']"/>
+        <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="TestNavigationDoubleClick.capella#5bc32968-2d29-42ca-8e79-15fc5e469937"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_g674gNr8Ee6g1ac8T6chTw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/EPBS.odesign#//@ownedViewpoints[name='EPBS%20architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_g7cO0Nr8Ee6g1ac8T6chTw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/context.odesign#//@ownedViewpoints[name='System%20Analysis']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_g9A8INr8Ee6g1ac8T6chTw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_g98JMNr8Ee6g1ac8T6chTw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_PcDxYNr9Ee6g1ac8T6chTw" name="[PPD] PhysicalPath 2" repPath="#_PcCjQNr9Ee6g1ac8T6chTw" changeId="1709649183344">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Path%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.cs:PhysicalPath" href="TestNavigationDoubleClick.capella#bbc09123-f22e-49ad-80e8-3c47924e6541"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+  </viewpoint:DAnalysis>
+  <diagram:DSemanticDiagram uid="_kNlVANr8Ee6g1ac8T6chTw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_kNq0kNr8Ee6g1ac8T6chTw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_kNq0kdr8Ee6g1ac8T6chTw" type="Sirius" element="_kNlVANr8Ee6g1ac8T6chTw" measurementUnit="Pixel">
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_kNq0ktr8Ee6g1ac8T6chTw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_kNw7MNr8Ee6g1ac8T6chTw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_kNw7Mdr8Ee6g1ac8T6chTw"/>
+    </ownedAnnotationEntries>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_kNlVAdr8Ee6g1ac8T6chTw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="TestNavigationDoubleClick.capella#03df8c34-349f-4b7f-b8d4-8ef8a1047bc6"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_l3pDENr8Ee6g1ac8T6chTw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_l3q4QNr8Ee6g1ac8T6chTw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_l3q4Qdr8Ee6g1ac8T6chTw" type="Sirius" element="_l3pDENr8Ee6g1ac8T6chTw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_nKMQENr8Ee6g1ac8T6chTw" type="2002" element="_nKGJcNr8Ee6g1ac8T6chTw">
+          <children xmi:type="notation:Node" xmi:id="_nKMQE9r8Ee6g1ac8T6chTw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_nKMQFNr8Ee6g1ac8T6chTw" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_nKM3INr8Ee6g1ac8T6chTw" type="3008" element="_nKJz0tr8Ee6g1ac8T6chTw">
+              <children xmi:type="notation:Node" xmi:id="_nKM3I9r8Ee6g1ac8T6chTw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_nKM3JNr8Ee6g1ac8T6chTw" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_nKM3Jdr8Ee6g1ac8T6chTw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_nKM3Jtr8Ee6g1ac8T6chTw"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_nKM3J9r8Ee6g1ac8T6chTw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nKM3Idr8Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="12"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nKM3Itr8Ee6g1ac8T6chTw"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_nKMQFdr8Ee6g1ac8T6chTw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_nKMQFtr8Ee6g1ac8T6chTw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_nKMQEdr8Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nKMQEtr8Ee6g1ac8T6chTw" x="230" y="390"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_nlz1ENr8Ee6g1ac8T6chTw" type="2002" element="_nltucNr8Ee6g1ac8T6chTw">
+          <children xmi:type="notation:Node" xmi:id="_nl0cINr8Ee6g1ac8T6chTw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_nl0cIdr8Ee6g1ac8T6chTw" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_nl0cItr8Ee6g1ac8T6chTw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_nl0cI9r8Ee6g1ac8T6chTw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_nlz1Edr8Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nlz1Etr8Ee6g1ac8T6chTw" x="470" y="190"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_l3q4Qtr8Ee6g1ac8T6chTw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_l3uioNr8Ee6g1ac8T6chTw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_l3uiodr8Ee6g1ac8T6chTw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_nKGJcNr8Ee6g1ac8T6chTw" name="OperationalProcess 1" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="TestNavigationDoubleClick.capella#25ad13f5-d7f2-4578-9357-c7575ea201c4"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="TestNavigationDoubleClick.capella#25ad13f5-d7f2-4578-9357-c7575ea201c4"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="TestNavigationDoubleClick.capella#03df8c34-349f-4b7f-b8d4-8ef8a1047bc6"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nKGJcdr8Ee6g1ac8T6chTw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@conditionnalStyles.0/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_nKJz0tr8Ee6g1ac8T6chTw">
+        <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="TestNavigationDoubleClick.capella#03df8c34-349f-4b7f-b8d4-8ef8a1047bc6"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="TestNavigationDoubleClick.capella#03df8c34-349f-4b7f-b8d4-8ef8a1047bc6"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nKKa4Nr8Ee6g1ac8T6chTw" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@conditionnalStyles.0/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_nltucNr8Ee6g1ac8T6chTw" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="TestNavigationDoubleClick.capella#3c9ac5d5-6e2b-4ab4-a2c2-c04d75c7d3ca"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="TestNavigationDoubleClick.capella#3c9ac5d5-6e2b-4ab4-a2c2-c04d75c7d3ca"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_o0-989r8Ee6g1ac8T6chTw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_l3pDEdr8Ee6g1ac8T6chTw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="TestNavigationDoubleClick.capella#46631d60-ec95-42f6-b139-f150db02978a"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_0oeaINr8Ee6g1ac8T6chTw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_0ofoQNr8Ee6g1ac8T6chTw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_0ofoQdr8Ee6g1ac8T6chTw" type="Sirius" element="_0oeaINr8Ee6g1ac8T6chTw" measurementUnit="Pixel">
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_0ofoQtr8Ee6g1ac8T6chTw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_0ohdcNr8Ee6g1ac8T6chTw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_0ohdcdr8Ee6g1ac8T6chTw"/>
+    </ownedAnnotationEntries>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_0oeaIdr8Ee6g1ac8T6chTw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="TestNavigationDoubleClick.capella#fa753755-2732-4c2f-8877-89152e3e34f7"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_20T_kNr8Ee6g1ac8T6chTw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_20VNsNr8Ee6g1ac8T6chTw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_20VNsdr8Ee6g1ac8T6chTw" type="Sirius" element="_20T_kNr8Ee6g1ac8T6chTw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_3s3_QNr8Ee6g1ac8T6chTw" type="2002" element="_3swDcNr8Ee6g1ac8T6chTw">
+          <children xmi:type="notation:Node" xmi:id="_3s4mUNr8Ee6g1ac8T6chTw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_3s4mUdr8Ee6g1ac8T6chTw" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_3s4mVNr8Ee6g1ac8T6chTw" type="3008" element="_3syfstr8Ee6g1ac8T6chTw">
+              <children xmi:type="notation:Node" xmi:id="_3s4mV9r8Ee6g1ac8T6chTw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_3s4mWNr8Ee6g1ac8T6chTw" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_3s4mWdr8Ee6g1ac8T6chTw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_3s4mWtr8Ee6g1ac8T6chTw"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_3s4mW9r8Ee6g1ac8T6chTw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3s4mVdr8Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3s4mVtr8Ee6g1ac8T6chTw"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_3s4mUtr8Ee6g1ac8T6chTw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_3s4mU9r8Ee6g1ac8T6chTw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3s3_Qdr8Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3s3_Qtr8Ee6g1ac8T6chTw" x="340" y="380"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_4DWlkNr8Ee6g1ac8T6chTw" type="2002" element="_4DOpwNr8Ee6g1ac8T6chTw">
+          <children xmi:type="notation:Node" xmi:id="_4DWlk9r8Ee6g1ac8T6chTw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_4DWllNr8Ee6g1ac8T6chTw" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_4DWlldr8Ee6g1ac8T6chTw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_4DWlltr8Ee6g1ac8T6chTw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_4DWlkdr8Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4DWlktr8Ee6g1ac8T6chTw" x="640" y="280"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_20VNstr8Ee6g1ac8T6chTw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_20XC4Nr8Ee6g1ac8T6chTw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_20XC4dr8Ee6g1ac8T6chTw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_3swDcNr8Ee6g1ac8T6chTw" name="FunctionalChain 1" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="TestNavigationDoubleClick.capella#3ab16faf-28f8-4cf8-a3c8-46c099598e78"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="TestNavigationDoubleClick.capella#3ab16faf-28f8-4cf8-a3c8-46c099598e78"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="TestNavigationDoubleClick.capella#fa753755-2732-4c2f-8877-89152e3e34f7"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_3swDcdr8Ee6g1ac8T6chTw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_3syfstr8Ee6g1ac8T6chTw">
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="TestNavigationDoubleClick.capella#fa753755-2732-4c2f-8877-89152e3e34f7"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="TestNavigationDoubleClick.capella#fa753755-2732-4c2f-8877-89152e3e34f7"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_3syfs9r8Ee6g1ac8T6chTw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_4DOpwNr8Ee6g1ac8T6chTw" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="TestNavigationDoubleClick.capella#86fb844b-0809-4ce1-9c0e-172f994b81ca"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="TestNavigationDoubleClick.capella#86fb844b-0809-4ce1-9c0e-172f994b81ca"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_4DOpwdr8Ee6g1ac8T6chTw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_20T_kdr8Ee6g1ac8T6chTw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="TestNavigationDoubleClick.capella#57c6baa8-e679-4612-81d0-466aae821398"/>
+  </diagram:DSemanticDiagram>
+  <sequence:SequenceDDiagram uid="_AsSxUNr9Ee6g1ac8T6chTw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_AsWbsNr9Ee6g1ac8T6chTw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_AsWbsdr9Ee6g1ac8T6chTw" type="Sirius" element="_AsSxUNr9Ee6g1ac8T6chTw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_Asio8dr9Ee6g1ac8T6chTw" type="2001" element="_AsatINr9Ee6g1ac8T6chTw">
+          <children xmi:type="notation:Node" xmi:id="_AsjQANr9Ee6g1ac8T6chTw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_AsjQAdr9Ee6g1ac8T6chTw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Asj3ENr9Ee6g1ac8T6chTw" type="3001" element="_AsciUNr9Ee6g1ac8T6chTw">
+            <children xmi:type="notation:Node" xmi:id="_Asj3E9r9Ee6g1ac8T6chTw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Asj3FNr9Ee6g1ac8T6chTw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_AslsQNr9Ee6g1ac8T6chTw" type="3003" element="_AsciUdr9Ee6g1ac8T6chTw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_AslsQdr9Ee6g1ac8T6chTw" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AslsQtr9Ee6g1ac8T6chTw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_AslsQ9r9Ee6g1ac8T6chTw" type="3001" element="_Ase-kNr9Ee6g1ac8T6chTw">
+              <children xmi:type="notation:Node" xmi:id="_AslsRtr9Ee6g1ac8T6chTw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_AslsR9r9Ee6g1ac8T6chTw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_AwO2INr9Ee6g1ac8T6chTw" type="3005" element="_Ase-kdr9Ee6g1ac8T6chTw">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_AwO2Idr9Ee6g1ac8T6chTw" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AwO2Itr9Ee6g1ac8T6chTw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_AslsRNr9Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AslsRdr9Ee6g1ac8T6chTw" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Asj3Edr9Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Asj3Etr9Ee6g1ac8T6chTw" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_AslFMNr9Ee6g1ac8T6chTw" type="3003" element="_Asb7QNr9Ee6g1ac8T6chTw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_AslFMdr9Ee6g1ac8T6chTw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AslFMtr9Ee6g1ac8T6chTw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Asio8tr9Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Asio89r9Ee6g1ac8T6chTw" x="50" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Ex570Nr9Ee6g1ac8T6chTw" type="2002" element="_ExeeANr9Ee6g1ac8T6chTw">
+          <children xmi:type="notation:Node" xmi:id="_Ex6i4Nr9Ee6g1ac8T6chTw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_Ex6i4dr9Ee6g1ac8T6chTw" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_Ex6i4tr9Ee6g1ac8T6chTw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_Ex6i49r9Ee6g1ac8T6chTw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Ex570dr9Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ex570tr9Ee6g1ac8T6chTw" x="50" y="209" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_FZYykNr9Ee6g1ac8T6chTw" type="2002" element="_FZECcNr9Ee6g1ac8T6chTw">
+          <children xmi:type="notation:Node" xmi:id="_FZYyk9r9Ee6g1ac8T6chTw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_FZYylNr9Ee6g1ac8T6chTw" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_FZYyldr9Ee6g1ac8T6chTw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_FZYyltr9Ee6g1ac8T6chTw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_FZYykdr9Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FZYyktr9Ee6g1ac8T6chTw" x="50" y="322" width="150" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_AsWbstr9Ee6g1ac8T6chTw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_AsiB4Nr9Ee6g1ac8T6chTw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_Asio8Nr9Ee6g1ac8T6chTw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_AsatINr9Ee6g1ac8T6chTw" name="System" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#48fb4cbb-d758-4729-b267-cfd402a983de"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#48fb4cbb-d758-4729-b267-cfd402a983de"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="TestNavigationDoubleClick.capella#0bc06762-5f37-4955-9e0c-5060670d267a"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.ctx:SystemComponent" href="TestNavigationDoubleClick.capella#6368b8d8-e846-4484-ae7d-d6c268015148"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_A1hl0Nr9Ee6g1ac8T6chTw" x="50" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_AsciUNr9Ee6g1ac8T6chTw" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#48fb4cbb-d758-4729-b267-cfd402a983de"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#48fb4cbb-d758-4729-b267-cfd402a983de"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="TestNavigationDoubleClick.capella#0bc06762-5f37-4955-9e0c-5060670d267a"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.ctx:SystemComponent" href="TestNavigationDoubleClick.capella#6368b8d8-e846-4484-ae7d-d6c268015148"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Ase-kNr9Ee6g1ac8T6chTw" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#48fb4cbb-d758-4729-b267-cfd402a983de"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#48fb4cbb-d758-4729-b267-cfd402a983de"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="TestNavigationDoubleClick.capella#0bc06762-5f37-4955-9e0c-5060670d267a"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.ctx:SystemComponent" href="TestNavigationDoubleClick.capella#6368b8d8-e846-4484-ae7d-d6c268015148"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_Ase-kdr9Ee6g1ac8T6chTw" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_AsciUdr9Ee6g1ac8T6chTw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_Asb7QNr9Ee6g1ac8T6chTw" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.4/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_ExeeANr9Ee6g1ac8T6chTw" name=" ref">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="TestNavigationDoubleClick.capella#a54d2421-ac33-44b1-b4eb-171a3d0cf514"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="TestNavigationDoubleClick.capella#a54d2421-ac33-44b1-b4eb-171a3d0cf514"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="TestNavigationDoubleClick.capella#5bc32968-2d29-42ca-8e79-15fc5e469937"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.ctx:Capability" href="TestNavigationDoubleClick.capella#240e92b3-e0ea-4eb3-b0f1-61788a28613e"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_ExfsINr9Ee6g1ac8T6chTw" x="50" y="209" height="50" width="150"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_ExfFENr9Ee6g1ac8T6chTw" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" foregroundColor="242,242,242">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUseDF']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InteractionUseMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUseDF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_FZECcNr9Ee6g1ac8T6chTw" name=" ref">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="TestNavigationDoubleClick.capella#829bfc17-79c4-4889-ad60-ead193522e12"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="TestNavigationDoubleClick.capella#829bfc17-79c4-4889-ad60-ead193522e12"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_FZECc9r9Ee6g1ac8T6chTw" x="50" y="322" height="50" width="150"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_FZECcdr9Ee6g1ac8T6chTw" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" foregroundColor="242,242,242">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUseDF']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InteractionUseMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUseDF']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_AsUmgNr9Ee6g1ac8T6chTw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="TestNavigationDoubleClick.capella#036e128b-414b-42a9-aa2e-e04f381aaa0e"/>
+  </sequence:SequenceDDiagram>
+  <sequence:SequenceDDiagram uid="_Duxq4Nr9Ee6g1ac8T6chTw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Du0HINr9Ee6g1ac8T6chTw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_Du0HIdr9Ee6g1ac8T6chTw" type="Sirius" element="_Duxq4Nr9Ee6g1ac8T6chTw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_Du3Kctr9Ee6g1ac8T6chTw" type="2001" element="_Du0uMNr9Ee6g1ac8T6chTw">
+          <children xmi:type="notation:Node" xmi:id="_Du3xgNr9Ee6g1ac8T6chTw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_Du3xgdr9Ee6g1ac8T6chTw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Du3xgtr9Ee6g1ac8T6chTw" type="3001" element="_Du0uM9r9Ee6g1ac8T6chTw">
+            <children xmi:type="notation:Node" xmi:id="_Du3xhdr9Ee6g1ac8T6chTw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Du3xhtr9Ee6g1ac8T6chTw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Du3xitr9Ee6g1ac8T6chTw" type="3003" element="_Du0uNNr9Ee6g1ac8T6chTw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Du4YkNr9Ee6g1ac8T6chTw" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Du4Ykdr9Ee6g1ac8T6chTw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Du4Yktr9Ee6g1ac8T6chTw" type="3001" element="_Du1VQdr9Ee6g1ac8T6chTw">
+              <children xmi:type="notation:Node" xmi:id="_Du4Yldr9Ee6g1ac8T6chTw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_Du4Yltr9Ee6g1ac8T6chTw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_Du-fMNr9Ee6g1ac8T6chTw" type="3005" element="_Du1VQtr9Ee6g1ac8T6chTw">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_Du-fMdr9Ee6g1ac8T6chTw" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Du-fMtr9Ee6g1ac8T6chTw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Du4Yk9r9Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Du4YlNr9Ee6g1ac8T6chTw" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Du3xg9r9Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Du3xhNr9Ee6g1ac8T6chTw" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Du3xh9r9Ee6g1ac8T6chTw" type="3003" element="_Du0uMdr9Ee6g1ac8T6chTw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Du3xiNr9Ee6g1ac8T6chTw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Du3xidr9Ee6g1ac8T6chTw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Du3Kc9r9Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Du3KdNr9Ee6g1ac8T6chTw" x="50" y="50" width="150" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_Du0HItr9Ee6g1ac8T6chTw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Du3KcNr9Ee6g1ac8T6chTw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_Du3Kcdr9Ee6g1ac8T6chTw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_Du0uMNr9Ee6g1ac8T6chTw" name="System" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#5ce484d6-cbf4-4d23-93b2-523f4f78ed6c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#5ce484d6-cbf4-4d23-93b2-523f4f78ed6c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="TestNavigationDoubleClick.capella#0bc06762-5f37-4955-9e0c-5060670d267a"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.ctx:SystemComponent" href="TestNavigationDoubleClick.capella#6368b8d8-e846-4484-ae7d-d6c268015148"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_DxMFsNr9Ee6g1ac8T6chTw" x="50" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Du0uM9r9Ee6g1ac8T6chTw" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#5ce484d6-cbf4-4d23-93b2-523f4f78ed6c"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#5ce484d6-cbf4-4d23-93b2-523f4f78ed6c"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="TestNavigationDoubleClick.capella#0bc06762-5f37-4955-9e0c-5060670d267a"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.ctx:SystemComponent" href="TestNavigationDoubleClick.capella#6368b8d8-e846-4484-ae7d-d6c268015148"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Du1VQdr9Ee6g1ac8T6chTw" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#5ce484d6-cbf4-4d23-93b2-523f4f78ed6c"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="TestNavigationDoubleClick.capella#5ce484d6-cbf4-4d23-93b2-523f4f78ed6c"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="TestNavigationDoubleClick.capella#0bc06762-5f37-4955-9e0c-5060670d267a"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.ctx:SystemComponent" href="TestNavigationDoubleClick.capella#6368b8d8-e846-4484-ae7d-d6c268015148"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_Du1VQtr9Ee6g1ac8T6chTw" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_Du0uNNr9Ee6g1ac8T6chTw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_Du0uMdr9Ee6g1ac8T6chTw" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.4/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_DuyR8Nr9Ee6g1ac8T6chTw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="TestNavigationDoubleClick.capella#5bc32968-2d29-42ca-8e79-15fc5e469937"/>
+  </sequence:SequenceDDiagram>
+  <diagram:DSemanticDiagram uid="_PcCjQNr9Ee6g1ac8T6chTw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_PcEYcNr9Ee6g1ac8T6chTw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_PcE_gNr9Ee6g1ac8T6chTw" type="Sirius" element="_PcCjQNr9Ee6g1ac8T6chTw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_P-6m0Nr9Ee6g1ac8T6chTw" type="2001" element="_P-qvMNr9Ee6g1ac8T6chTw">
+          <children xmi:type="notation:Node" xmi:id="_P-6m09r9Ee6g1ac8T6chTw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_P-6m1Nr9Ee6g1ac8T6chTw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_P-6m1dr9Ee6g1ac8T6chTw" type="3003" element="_P-qvMdr9Ee6g1ac8T6chTw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_P-6m1tr9Ee6g1ac8T6chTw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P-6m19r9Ee6g1ac8T6chTw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_P-6m0dr9Ee6g1ac8T6chTw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P-6m0tr9Ee6g1ac8T6chTw" x="480" y="200"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_PcE_gdr9Ee6g1ac8T6chTw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_PcG0sNr9Ee6g1ac8T6chTw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_PcG0sdr9Ee6g1ac8T6chTw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_P-qvMNr9Ee6g1ac8T6chTw" name="PhysicalPath 1" width="5" height="5" resizeKind="NSEW">
+      <target xmi:type="org.polarsys.capella.core.data.cs:PhysicalPathReference" href="TestNavigationDoubleClick.capella#c51fbc42-5749-4525-a63f-10ef7b21ba85"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:PhysicalPathReference" href="TestNavigationDoubleClick.capella#c51fbc42-5749-4525-a63f-10ef7b21ba85"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:PhysicalPath" href="TestNavigationDoubleClick.capella#0447a15a-fc6a-4388-b153-7e8fe5a64b12"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_P-qvMdr9Ee6g1ac8T6chTw" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136" labelPosition="node" width="-1" height="-1" color="255,245,181">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Path%20Description']/@defaultLayer/@nodeMappings[name='PPD_PhysicalPath']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Path%20Description']/@defaultLayer/@nodeMappings[name='PPD_PhysicalPath']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Path%20Description']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_PcCjQdr9Ee6g1ac8T6chTw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Path%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.cs:PhysicalPath" href="TestNavigationDoubleClick.capella#bbc09123-f22e-49ad-80e8-3c47924e6541"/>
+  </diagram:DSemanticDiagram>
+</xmi:XMI>

--- a/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/TestNavigationDoubleClick.capella
+++ b/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/TestNavigationDoubleClick.capella
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--Capella_Version_7.0.0-->
+<org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"
+    xmlns:org.polarsys.capella.core.data.capellamodeller="http://www.polarsys.org/capella/core/modeller/7.0.0"
+    xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
+    xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/7.0.0"
+    xmlns:org.polarsys.capella.core.data.epbs="http://www.polarsys.org/capella/core/epbs/7.0.0"
+    xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/7.0.0"
+    xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/7.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datatype="http://www.polarsys.org/capella/core/information/datatype/7.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datavalue="http://www.polarsys.org/capella/core/information/datavalue/7.0.0"
+    xmlns:org.polarsys.capella.core.data.interaction="http://www.polarsys.org/capella/core/interaction/7.0.0"
+    xmlns:org.polarsys.capella.core.data.la="http://www.polarsys.org/capella/core/la/7.0.0"
+    xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/7.0.0"
+    xmlns:org.polarsys.capella.core.data.pa="http://www.polarsys.org/capella/core/pa/7.0.0"
+    id="d3536ed5-45ab-43eb-a2c3-e5ba8620be4e"
+    name="TestNavigationDoubleClick">
+  <ownedExtensions xsi:type="libraries:ModelInformation" id="4c331d0b-d31f-4156-9f32-e6555f17a124"/>
+  <ownedEnumerationPropertyTypes xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyType"
+      id="33760630-5195-48b8-8a8a-15ccc08f2de3" name="ProgressStatus">
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="00cc686e-9ec8-4445-8e5f-c0568b5f7dee" name="DRAFT"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="89f71144-755e-4b7c-9853-fea26d91dbbd" name="TO_BE_REVIEWED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="567b4327-f014-4805-b825-085b0da0d8cc" name="TO_BE_DISCUSSED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="258b0054-0df9-40a7-b627-a0993af3441a" name="REWORK_NECESSARY"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="b2d0019e-5dbe-47a3-a8fc-60f8d2c69737" name="UNDER_REWORK"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="fb7f8014-8796-447e-8f0a-7cb08550aafd" name="REVIEWED_OK"/>
+  </ownedEnumerationPropertyTypes>
+  <keyValuePairs xsi:type="org.polarsys.capella.core.data.capellacore:KeyValue" id="3a2bbcd5-70f0-4b68-bfd8-1db33a7d36ff"
+      key="projectApproach" value="SingletonComponents"/>
+  <ownedModelRoots xsi:type="org.polarsys.capella.core.data.capellamodeller:SystemEngineering"
+      id="68bd7d89-52e8-4333-b1d0-129f66e4cd7e" name="TestNavigationDoubleClick">
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.oa:OperationalAnalysis"
+        id="d9dedaf3-fe1d-458d-9193-3eba7fca1931" name="Operational Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalActivityPkg"
+          id="ab4a61f3-9909-4366-8dcc-55d5be86e0fa" name="Operational Activities">
+        <ownedOperationalActivities xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
+            id="101a4452-68aa-44bc-9cc7-aaaba12396a0" name="Root Operational Activity">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.oa:OperationalProcess"
+              id="03df8c34-349f-4b7f-b8d4-8ef8a1047bc6" name="OperationalProcess 1"/>
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.oa:OperationalProcess"
+              id="46631d60-ec95-42f6-b139-f150db02978a" name="OperationalProcess 2">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="25ad13f5-d7f2-4578-9357-c7575ea201c4" involved="#03df8c34-349f-4b7f-b8d4-8ef8a1047bc6"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="3c9ac5d5-6e2b-4ab4-a2c2-c04d75c7d3ca"/>
+          </ownedFunctionalChains>
+        </ownedOperationalActivities>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalCapabilityPkg"
+          id="9f32f1ff-86bc-4b55-b58c-e1ac0992bcfa" name="Operational Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="23ea4118-2bd1-4f61-8b86-291fbe0d0091" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="afac2245-0e65-4f50-9bad-de7ea3d3f8ea" name="Data"/>
+      <ownedRolePkg xsi:type="org.polarsys.capella.core.data.oa:RolePkg" id="f88a7442-f3f3-4988-b88d-494046fd7a2e"
+          name="Roles"/>
+      <ownedEntityPkg xsi:type="org.polarsys.capella.core.data.oa:EntityPkg" id="9b7b9bf3-d61a-4ba9-88b3-cd5a9d66da01"
+          name="Operational Entities"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.ctx:SystemAnalysis"
+        id="bec8d4f7-24c1-4fd1-8ef3-1dad475ab8d4" name="System Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemFunctionPkg"
+          id="3b4577ce-c0f7-418b-9a65-46b52ed51244" name="System Functions">
+        <ownedSystemFunctions xsi:type="org.polarsys.capella.core.data.ctx:SystemFunction"
+            id="01198b60-8aa2-43fb-9448-4bbcb5e46afe" name="Root System Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="d19da59f-3864-43e3-bde6-02979f25fd75" targetElement="#101a4452-68aa-44bc-9cc7-aaaba12396a0"
+              sourceElement="#01198b60-8aa2-43fb-9448-4bbcb5e46afe"/>
+        </ownedSystemFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.ctx:CapabilityPkg"
+          id="c42495f0-492a-4dc6-acdc-f1cbf9384f91" name="Capabilities">
+        <ownedCapabilities xsi:type="org.polarsys.capella.core.data.ctx:Capability"
+            id="240e92b3-e0ea-4eb3-b0f1-61788a28613e" name="Capability 1">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="fa753755-2732-4c2f-8877-89152e3e34f7" name="FunctionalChain 1"/>
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="57c6baa8-e679-4612-81d0-466aae821398" name="FunctionalChain 2">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="3ab16faf-28f8-4cf8-a3c8-46c099598e78" involved="#fa753755-2732-4c2f-8877-89152e3e34f7"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="86fb844b-0809-4ce1-9c0e-172f994b81ca"/>
+          </ownedFunctionalChains>
+          <ownedScenarios xsi:type="org.polarsys.capella.core.data.interaction:Scenario"
+              id="5bc32968-2d29-42ca-8e79-15fc5e469937" name="[ES] Scenario 1" kind="DATA_FLOW">
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="5ce484d6-cbf4-4d23-93b2-523f4f78ed6c" name="System" representedInstance="#0bc06762-5f37-4955-9e0c-5060670d267a"/>
+          </ownedScenarios>
+          <ownedScenarios xsi:type="org.polarsys.capella.core.data.interaction:Scenario"
+              id="036e128b-414b-42a9-aa2e-e04f381aaa0e" name="[ES] Scenario 2" kind="DATA_FLOW">
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="48fb4cbb-d758-4729-b267-cfd402a983de" name="System" representedInstance="#0bc06762-5f37-4955-9e0c-5060670d267a"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="d0fa4dc3-2652-4123-bab2-9afb969da391" name="start" coveredInstanceRoles="#48fb4cbb-d758-4729-b267-cfd402a983de"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="bfb75366-9175-4866-b1d0-df993a3570fb" name="end" coveredInstanceRoles="#48fb4cbb-d758-4729-b267-cfd402a983de"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="f1ef7026-3c32-4071-992b-42b8d5e4e4fc" name="start" coveredInstanceRoles="#48fb4cbb-d758-4729-b267-cfd402a983de"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="585258cf-1e07-4822-b3c7-02dc2b9b75a5" name="end" coveredInstanceRoles="#48fb4cbb-d758-4729-b267-cfd402a983de"/>
+            <ownedTimeLapses xsi:type="org.polarsys.capella.core.data.interaction:InteractionUse"
+                id="a54d2421-ac33-44b1-b4eb-171a3d0cf514" name="interactionUse" start="#d0fa4dc3-2652-4123-bab2-9afb969da391"
+                finish="#bfb75366-9175-4866-b1d0-df993a3570fb" referencedScenario="#5bc32968-2d29-42ca-8e79-15fc5e469937"/>
+            <ownedTimeLapses xsi:type="org.polarsys.capella.core.data.interaction:InteractionUse"
+                id="829bfc17-79c4-4889-ad60-ead193522e12" name="interactionUse" start="#f1ef7026-3c32-4071-992b-42b8d5e4e4fc"
+                finish="#585258cf-1e07-4822-b3c7-02dc2b9b75a5"/>
+          </ownedScenarios>
+          <ownedCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.ctx:CapabilityInvolvement"
+              id="1c993975-624d-411e-80a5-66273a58466e" involved="#6368b8d8-e846-4484-ae7d-d6c268015148"/>
+        </ownedCapabilities>
+      </ownedAbstractCapabilityPkg>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="fa7f29ee-9807-4918-b879-b7dad8062198" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="966c1752-9371-49ee-bacf-f63618d7fcf6" name="Data">
+        <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+            id="eddb5c62-d078-4039-9c2f-d8f939ab2079" name="Predefined Types">
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"
+              id="f1094be4-abeb-4f3b-b08f-4382310addf2" name="Boolean" visibility="PUBLIC">
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="ba652f55-4873-4c4b-a9d9-5d5a71a4ee10" name="True" abstractType="#f1094be4-abeb-4f3b-b08f-4382310addf2"
+                value="true"/>
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="7617ebcc-8f7f-4000-936a-7134a7b9aada" name="False" abstractType="#f1094be4-abeb-4f3b-b08f-4382310addf2"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="a43f29c1-8569-4106-9411-05188f714658" name="Byte" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="ebcc5812-49a3-49f7-af53-f7cdab72a4d1" name="" abstractType="#a43f29c1-8569-4106-9411-05188f714658"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="7c6f3227-62cb-46eb-bd8f-7df33ffb33e5" name="" abstractType="#a43f29c1-8569-4106-9411-05188f714658"
+                value="255"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="aadf18b8-3790-4399-ae1a-cceab4b0b8a5" name="Char" visibility="PUBLIC">
+            <ownedMinLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="1aab6391-b2d9-4776-94cf-c0f6f9686b7a" name="" abstractType="#15c7c91d-e198-422a-8316-5464f8ae85f0"
+                value="1"/>
+            <ownedMaxLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="799b29cf-4358-436f-bdb2-8cc405a146b4" name="" abstractType="#15c7c91d-e198-422a-8316-5464f8ae85f0"
+                value="1"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="eb977eac-488f-48f0-b0bc-cbdb4e196aeb" name="Double" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="5dfd88c5-63c4-4565-ae23-829f8a3b7d98" name="Float" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="56bf8785-db86-483b-97fe-2bfbcc1fee3f" name="Hexadecimal" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="2a169b54-16c5-47a7-bfdd-5f2b64b5c09a" name="" abstractType="#56bf8785-db86-483b-97fe-2bfbcc1fee3f"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                id="858a8622-c9f0-4224-8171-1963dfc56b73" abstractType="#56bf8785-db86-483b-97fe-2bfbcc1fee3f"
+                operator="SUB">
+              <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                  id="ac1a370d-e6aa-45b7-a149-199f92f72095" operator="POW">
+                <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="1df4855e-d6dc-4910-b872-f11fe9278818" value="2"/>
+                <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="a3d67fd0-eb34-415b-a53b-5433f2057d85" value="64"/>
+              </ownedLeftOperand>
+              <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                  id="55d0c64c-f192-4f16-b6f8-b0241e41709d" value="1"/>
+            </ownedMaxValue>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="ea29d237-953a-4ca2-a2a6-eed68129e0be" name="Integer" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="84dacb70-8d0a-4c96-a339-8caf0e2bfd43" name="Long" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="4163b4c8-ddde-4414-8f69-fa15ee0c2664" name="LongLong" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="081bd7ac-a086-46a9-9d29-b8f6f6ac210e" name="Short" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="310e4a8a-a739-46bb-aa68-19fa9ed69097" name="String" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="7dedb819-6070-4fe1-a505-5ce3c42c3f89" name="UnsignedInteger" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="9d46b668-5f3b-4905-a200-ef6c73456f59" name="" abstractType="#7dedb819-6070-4fe1-a505-5ce3c42c3f89"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="15c7c91d-e198-422a-8316-5464f8ae85f0" name="UnsignedShort" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="2486d5e3-ab2d-4052-908e-19f5f13067bb" name="" abstractType="#15c7c91d-e198-422a-8316-5464f8ae85f0"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="4dff8182-bc72-45aa-b263-0590ac764d8a" name="UnsignedLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="cc79917a-7875-4fab-98d8-95060f92609e" name="" abstractType="#4dff8182-bc72-45aa-b263-0590ac764d8a"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="70357fd2-2c75-4b70-a9e7-521bce1a705c" name="UnsignedLongLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="867d8bef-8225-40c7-9589-7645918936b3" name="" abstractType="#70357fd2-2c75-4b70-a9e7-521bce1a705c"
+                value="0"/>
+          </ownedDataTypes>
+        </ownedDataPkgs>
+      </ownedDataPkg>
+      <ownedSystemComponentPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemComponentPkg"
+          id="24c809f9-7ef6-49c4-b6c6-57fbfd2d5c38" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="0bc06762-5f37-4955-9e0c-5060670d267a"
+            name="System" abstractType="#6368b8d8-e846-4484-ae7d-d6c268015148"/>
+        <ownedSystemComponents xsi:type="org.polarsys.capella.core.data.ctx:SystemComponent"
+            id="6368b8d8-e846-4484-ae7d-d6c268015148" name="System">
+          <ownedStateMachines xsi:type="org.polarsys.capella.core.data.capellacommon:StateMachine"
+              id="10e1d055-e8bd-4bf5-a071-59299503be12" name="System State Machine">
+            <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                id="95e3f86f-11ca-4640-ae97-1cce4191c937" name="Default Region"/>
+          </ownedStateMachines>
+        </ownedSystemComponents>
+      </ownedSystemComponentPkg>
+      <ownedMissionPkg xsi:type="org.polarsys.capella.core.data.ctx:MissionPkg" id="7853f800-720c-4948-b510-84197281e92c"
+          name="Missions"/>
+      <ownedOperationalAnalysisRealizations xsi:type="org.polarsys.capella.core.data.ctx:OperationalAnalysisRealization"
+          id="2ad63ce5-8a75-434c-9532-ab4f5c472c4f" targetElement="#d9dedaf3-fe1d-458d-9193-3eba7fca1931"
+          sourceElement="#bec8d4f7-24c1-4fd1-8ef3-1dad475ab8d4"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.la:LogicalArchitecture"
+        id="7593c6fd-f808-483c-a77e-ef4e71a668a0" name="Logical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.la:LogicalFunctionPkg"
+          id="ea2c2991-37a8-4056-9845-08cc2b974c92" name="Logical Functions">
+        <ownedLogicalFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
+            id="954a18d2-a798-47a2-be79-ceca9bf7bd36" name="Root Logical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="676477b9-67ac-40d9-ae90-c23786e1dd05" targetElement="#01198b60-8aa2-43fb-9448-4bbcb5e46afe"
+              sourceElement="#954a18d2-a798-47a2-be79-ceca9bf7bd36"/>
+        </ownedLogicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="68bc7e6e-47d8-4c3b-9e18-6fb9c026f90b" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="1cf2e3ec-00a0-46ab-9e36-b2139eb6635c" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="207c0658-d24b-40d2-ae70-de7a8e4cabd7" name="Data"/>
+      <ownedLogicalComponentPkg xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"
+          id="d991c1ed-e9b1-469e-97dd-7db048f2c1f5" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="64a62cc9-ee00-4acc-941b-7d239baa2cc8"
+            name="Logical System" abstractType="#ccdf3340-b70f-4c76-8323-9cdb00a73b76"/>
+        <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+            id="ccdf3340-b70f-4c76-8323-9cdb00a73b76" name="Logical System">
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="51112bbf-cd71-4615-9a9f-172836eea843" targetElement="#6368b8d8-e846-4484-ae7d-d6c268015148"
+              sourceElement="#ccdf3340-b70f-4c76-8323-9cdb00a73b76"/>
+        </ownedLogicalComponents>
+      </ownedLogicalComponentPkg>
+      <ownedSystemAnalysisRealizations xsi:type="org.polarsys.capella.core.data.la:SystemAnalysisRealization"
+          id="7b56a2b7-094a-4e67-b748-79ea7f62c7b0" targetElement="#bec8d4f7-24c1-4fd1-8ef3-1dad475ab8d4"
+          sourceElement="#7593c6fd-f808-483c-a77e-ef4e71a668a0"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.pa:PhysicalArchitecture"
+        id="dc4bb267-3e62-4612-90cb-d35b48a024bc" name="Physical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunctionPkg"
+          id="d9f49b23-e0ca-4fba-bf6a-64791628c6ee" name="Physical Functions">
+        <ownedPhysicalFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+            id="667c0a37-0de3-4a37-bdfc-16a9566d7229" name="Root Physical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="1bd2eb22-1127-4941-ab03-fe221323e43a" targetElement="#954a18d2-a798-47a2-be79-ceca9bf7bd36"
+              sourceElement="#667c0a37-0de3-4a37-bdfc-16a9566d7229"/>
+        </ownedPhysicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="eac9e770-c46a-44a3-baec-63949b984dac" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="00314173-cd33-4209-8060-f01c6a3d351e" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="9c585c76-3260-4fc3-bb74-303a5c8c7366" name="Data"/>
+      <ownedPhysicalComponentPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg"
+          id="57e514e1-bfc8-4941-bead-fd51d5dfcaec" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="8f643f86-3d29-4c92-a956-d51a538359c5"
+            name="Physical System" abstractType="#3d7abb3d-d61b-456e-97b7-3791b89d0eaf"/>
+        <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+            id="3d7abb3d-d61b-456e-97b7-3791b89d0eaf" name="Physical System">
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="5371df28-d94e-449c-b1bf-5ce62cd8a804" targetElement="#ccdf3340-b70f-4c76-8323-9cdb00a73b76"
+              sourceElement="#3d7abb3d-d61b-456e-97b7-3791b89d0eaf"/>
+          <ownedPhysicalPath xsi:type="org.polarsys.capella.core.data.cs:PhysicalPath"
+              id="0447a15a-fc6a-4388-b153-7e8fe5a64b12" name="PhysicalPath 1"/>
+          <ownedPhysicalPath xsi:type="org.polarsys.capella.core.data.cs:PhysicalPath"
+              id="bbc09123-f22e-49ad-80e8-3c47924e6541" name="PhysicalPath 2">
+            <ownedPhysicalPathInvolvements xsi:type="org.polarsys.capella.core.data.cs:PhysicalPathReference"
+                id="c51fbc42-5749-4525-a63f-10ef7b21ba85" involved="#0447a15a-fc6a-4388-b153-7e8fe5a64b12"/>
+            <ownedPhysicalPathInvolvements xsi:type="org.polarsys.capella.core.data.cs:PhysicalPathReference"
+                id="b81dc886-4527-4423-8f9d-96955c4145b1"/>
+          </ownedPhysicalPath>
+        </ownedPhysicalComponents>
+      </ownedPhysicalComponentPkg>
+      <ownedLogicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.pa:LogicalArchitectureRealization"
+          id="065af300-6e59-4308-8414-a6ba27723e2e" targetElement="#7593c6fd-f808-483c-a77e-ef4e71a668a0"
+          sourceElement="#dc4bb267-3e62-4612-90cb-d35b48a024bc"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.epbs:EPBSArchitecture"
+        id="1bf2b6db-dee6-42c2-857c-3a5cf2907414" name="EPBS Architecture">
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="96ac50e6-bc93-44a9-9e93-c5ce378a79ed" name="Capabilities"/>
+      <ownedConfigurationItemPkg xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItemPkg"
+          id="f89f74be-84e6-40e6-9b81-b9f8a1d365d6" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="264beb72-ecb1-4792-8a15-75ba462f1ea2"
+            name="System" abstractType="#986f34a6-1ad1-49bf-99df-cf67ef040d0f"/>
+        <ownedConfigurationItems xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem"
+            id="986f34a6-1ad1-49bf-99df-cf67ef040d0f" name="System" kind="SystemCI">
+          <ownedPhysicalArtifactRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArtifactRealization"
+              id="d0d93055-0f06-46ea-a4d8-d74ae76d433f" targetElement="#3d7abb3d-d61b-456e-97b7-3791b89d0eaf"
+              sourceElement="#986f34a6-1ad1-49bf-99df-cf67ef040d0f"/>
+        </ownedConfigurationItems>
+      </ownedConfigurationItemPkg>
+      <ownedPhysicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArchitectureRealization"
+          id="2c842a51-4117-4a31-aea9-28e86f4c7923" targetElement="#dc4bb267-3e62-4612-90cb-d35b48a024bc"
+          sourceElement="#1bf2b6db-dee6-42c2-857c-3a5cf2907414"/>
+    </ownedArchitectures>
+  </ownedModelRoots>
+</org.polarsys.capella.core.data.capellamodeller:Project>

--- a/tests/plugins/org.polarsys.capella.test.platform.ju/src/org/polarsys/capella/test/platform/ju/testcases/CapellaNavigateOnDoubleClickTestCase.java
+++ b/tests/plugins/org.polarsys.capella.test.platform.ju/src/org/polarsys/capella/test/platform/ju/testcases/CapellaNavigateOnDoubleClickTestCase.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2024 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.platform.ju.testcases;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.polarsys.capella.core.commands.preferences.preferences.CapellaDiagramPreferences;
+import org.polarsys.capella.core.commands.preferences.ui.sirius.DoubleClickBehaviourUtil;
+import org.polarsys.capella.core.libraries.model.CapellaModel;
+import org.polarsys.capella.core.preferences.Activator;
+import org.polarsys.capella.test.framework.api.BasicTestCase;
+import org.polarsys.capella.test.framework.helpers.EObjectHelper;
+
+public class CapellaNavigateOnDoubleClickTestCase extends BasicTestCase {
+  private static final String OPREF = "25ad13f5-d7f2-4578-9357-c7575ea201c4";
+  private static final String FCREF = "fa753755-2732-4c2f-8877-89152e3e34f7";
+  private static final String PPREF = "c51fbc42-5749-4525-a63f-10ef7b21ba85";
+  private static final String SCREF = "a54d2421-ac33-44b1-b4eb-171a3d0cf514";
+
+  private static final String OPREF_NOTARGET = "3c9ac5d5-6e2b-4ab4-a2c2-c04d75c7d3ca";
+  private static final String FCREF_NOTARGET = "86fb844b-0809-4ce1-9c0e-172f994b81ca";
+  private static final String PPREF_NOTARGET = "b81dc886-4527-4423-8f9d-96955c4145b1";
+  private static final String SCREF_NOTARGET = "829bfc17-79c4-4889-ad60-ead193522e12";
+
+  @Override
+  public void test() throws Exception {
+    CapellaModel model = getTestModel(getRequiredTestModels().iterator().next());
+    
+    boolean initialPreferenceValue =  Activator.getDefault().getPreferenceStore()
+            .getBoolean(CapellaDiagramPreferences.PREF_DISPLAY_NAVIGATE_ON_DOUBLE_CLICK);
+
+    // With navigation preference set to TRUE
+    Activator.getDefault().getPreferenceStore()
+        .setValue(CapellaDiagramPreferences.PREF_DISPLAY_NAVIGATE_ON_DOUBLE_CLICK, true);
+    testNavigationOnDoubleClick(model, OPREF, true);
+    testNavigationOnDoubleClick(model, FCREF, true);
+    testNavigationOnDoubleClick(model, PPREF, true);
+    testNavigationOnDoubleClick(model, SCREF, true);
+
+    // Navigation to reference with null target is always disabled (=false)
+    testNavigationOnDoubleClick(model, OPREF_NOTARGET, false);
+    testNavigationOnDoubleClick(model, FCREF_NOTARGET, false);
+    testNavigationOnDoubleClick(model, PPREF_NOTARGET, false);
+    testNavigationOnDoubleClick(model, SCREF_NOTARGET, false);
+
+    // With navigation preference set to FALSE
+    Activator.getDefault().getPreferenceStore()
+        .setValue(CapellaDiagramPreferences.PREF_DISPLAY_NAVIGATE_ON_DOUBLE_CLICK, false);
+
+    testNavigationOnDoubleClick(model, OPREF, false);
+    testNavigationOnDoubleClick(model, FCREF, false);
+    testNavigationOnDoubleClick(model, PPREF, false);
+    testNavigationOnDoubleClick(model, SCREF, false);
+
+    // Navigation to reference with null target is always disabled (=false)
+    testNavigationOnDoubleClick(model, OPREF_NOTARGET, false);
+    testNavigationOnDoubleClick(model, FCREF_NOTARGET, false);
+    testNavigationOnDoubleClick(model, PPREF_NOTARGET, false);
+    testNavigationOnDoubleClick(model, SCREF_NOTARGET, false);
+    
+    // Restore preference value
+    Activator.getDefault().getPreferenceStore()
+        .setValue(CapellaDiagramPreferences.PREF_DISPLAY_NAVIGATE_ON_DOUBLE_CLICK, initialPreferenceValue);
+  }
+
+  protected void testNavigationOnDoubleClick(CapellaModel model, String element, boolean expectedValue) {
+    EObject eObject = EObjectHelper.getObject(model, element);
+    boolean actualValue = DoubleClickBehaviourUtil.INSTANCE.shouldOpenRelatedDiagramsOnDoubleClick(eObject);
+    assertEquals(expectedValue, actualValue);
+  }
+
+  @Override
+  public List<String> getRequiredTestModels() {
+    return Collections.singletonList("TestNavigationDoubleClick");
+  }
+
+}

--- a/tests/plugins/org.polarsys.capella.test.platform.ju/src/org/polarsys/capella/test/platform/ju/testsuites/PlatformTestSuite.java
+++ b/tests/plugins/org.polarsys.capella.test.platform.ju/src/org/polarsys/capella/test/platform/ju/testsuites/PlatformTestSuite.java
@@ -23,6 +23,7 @@ import org.polarsys.capella.test.platform.ju.testcases.CapellaCDOGenerationOfDer
 import org.polarsys.capella.test.platform.ju.testcases.CapellaCheckAcceleo2NotUsed;
 import org.polarsys.capella.test.platform.ju.testcases.CapellaDefaultEditorEnabled;
 import org.polarsys.capella.test.platform.ju.testcases.CapellaLoggerConfigTestCase;
+import org.polarsys.capella.test.platform.ju.testcases.CapellaNavigateOnDoubleClickTestCase;
 import org.polarsys.capella.test.platform.ju.testcases.CapellaPlatformVersionNotNull;
 import org.polarsys.capella.test.platform.ju.testcases.CapellaSiriusCustomisationEnabled;
 import org.polarsys.capella.test.platform.ju.testcases.CapellaVersionConsistencyTest;
@@ -80,6 +81,7 @@ public class PlatformTestSuite extends BasicTestSuite {
     tests.add(new JobLogTest());
     tests.add(new CapellaLoggerConfigTestCase());
     tests.add(new CustomDAnalysisSelection());
+    tests.add(new CapellaNavigateOnDoubleClickTestCase());
 
     return tests;
   }


### PR DESCRIPTION
Fix issue where all available diagrams would be available in open diagram menu

double click now automatically opens wizard properties when target is null on FC/PP/Sc references

Fixed SWT  Leak in Capella wizard dialog

Change-Id: I7253303250f4506399932bdd903d8d95cebf0715