### PR TITLE
#2854 Remove invalid preconditions on table creation tools

### DIFF
--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/description/context.odesign
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/description/context.odesign
@@ -2115,7 +2115,7 @@
           </firstModelOperation>
           <mask mask="{0}"/>
         </directEdit>
-        <create name="FR3" precondition="aql:arg0 = 'X'" forceRefresh="true">
+        <create name="FR3" forceRefresh="true">
           <variables name="lineSemantic" documentation="The semantic element corresponding to the line."/>
           <variables name="columnSemantic" documentation="The semantic element corresponding to the column."/>
           <variables name="root" documentation="The semantic root element of the table."/>
@@ -5597,7 +5597,7 @@
           </firstModelOperation>
           <mask mask="{0}"/>
         </directEdit>
-        <create name="CFA" precondition="aql:arg0 = 'X'" forceRefresh="true">
+        <create name="CFA"  forceRefresh="true">
           <variables name="lineSemantic" documentation="The semantic element corresponding to the line."/>
           <variables name="columnSemantic" documentation="The semantic element corresponding to the column."/>
           <variables name="root" documentation="The semantic root element of the table."/>

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/description/logical.odesign
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/description/logical.odesign
@@ -47,7 +47,7 @@
           </firstModelOperation>
           <mask mask="{0}"/>
         </directEdit>
-        <create name="FR1" precondition="aql:arg0 = 'X'" forceRefresh="true">
+        <create name="FR1" forceRefresh="true">
           <variables name="lineSemantic" documentation="The semantic element corresponding to the line."/>
           <variables name="columnSemantic" documentation="The semantic element corresponding to the column."/>
           <variables name="root" documentation="The semantic root element of the table."/>
@@ -97,7 +97,7 @@
           </firstModelOperation>
           <mask mask="{0}"/>
         </directEdit>
-        <create name="CFA" precondition="aql:arg0 = 'X'" forceRefresh="true">
+        <create name="CFA" forceRefresh="true">
           <variables name="lineSemantic" documentation="The semantic element corresponding to the line."/>
           <variables name="columnSemantic" documentation="The semantic element corresponding to the column."/>
           <variables name="root" documentation="The semantic root element of the table."/>

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/description/physical.odesign
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/description/physical.odesign
@@ -47,7 +47,7 @@
           </firstModelOperation>
           <mask mask="{0}"/>
         </directEdit>
-        <create name="FR2" precondition="aql:arg0 = 'X'" forceRefresh="true">
+        <create name="FR2" forceRefresh="true">
           <variables name="lineSemantic" documentation="The semantic element corresponding to the line."/>
           <variables name="columnSemantic" documentation="The semantic element corresponding to the column."/>
           <variables name="root" documentation="The semantic root element of the table."/>
@@ -147,7 +147,7 @@
           </firstModelOperation>
           <mask mask="{0}"/>
         </directEdit>
-        <create name="CFA" precondition="aql:arg0 = 'X'" forceRefresh="true">
+        <create name="CFA" forceRefresh="true">
           <variables name="lineSemantic" documentation="The semantic element corresponding to the line."/>
           <variables name="columnSemantic" documentation="The semantic element corresponding to the column."/>
           <variables name="root" documentation="The semantic root element of the table."/>


### PR DESCRIPTION
These preconditions are now evaluated with Sirius 7.4.0 they are duplicated and invalid anyway

Change-Id: I75ab45634ec224cc468575d419c743076969b780