### PR TITLE
#2849 Fix Optional.orElseGet(null) leading to systematic error

### DIFF
--- a/core/plugins/org.polarsys.capella.core.sirius.ui/src/org/polarsys/capella/core/sirius/ui/actions/MoveRepresentationsAction.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.ui/src/org/polarsys/capella/core/sirius/ui/actions/MoveRepresentationsAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2020, 2024 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -52,7 +52,7 @@ public class MoveRepresentationsAction extends BaseSelectionListenerAction {
   @Override
   protected boolean updateSelection(IStructuredSelection selection) {
     List<DRepresentationDescriptor> validRepresentationDescriptors = getValidRepresentationDescriptors(selection);
-    List<Session> sessions = validRepresentationDescriptors.stream().map(repDesc -> Session.of(repDesc).orElseGet(null))
+    List<Session> sessions = validRepresentationDescriptors.stream().map(repDesc -> Session.of(repDesc).orElse(null))
         .filter(s -> s != null).distinct().collect(Collectors.toList());
     // The move action should be available only if the selections corresponds to the same session.
     if (sessions.size() == 1) {

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/src/org/polarsys/capella/test/transition/ju/transitions/CreateRule_ScenarioUml2_01.java
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/src/org/polarsys/capella/test/transition/ju/transitions/CreateRule_ScenarioUml2_01.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2019, 2024 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -133,7 +133,7 @@ public class CreateRule_ScenarioUml2_01 extends TopDownTransitionTestCase {
     assertNotNull(NLS.bind(Messages.NullElement, name), a4);
     EObject a4t = getAllocatingElements(a4).stream()
         .filter(s -> s instanceof Scenario && ((Scenario) s).getKind() == kind && EcoreUtil.isAncestor(container, s))
-        .findAny().orElseGet(null);
+        .findAny().orElse(null);
     String namet = name + "t"; //$NON-NLS-1$
     assertNotNull(NLS.bind(Messages.ShouldBeTransitioned, namet), a4t);
     String containerName = (container instanceof AbstractNamedElement ? ((AbstractNamedElement) container).getName()


### PR DESCRIPTION
Reopened for https://github.com/eclipse-capella/capella/pull/2850 (wrong branch name containing parenthesis, causing sonar command not to be evaluated)