### PR TITLE
Add timeout and disable concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,11 @@ pipeline {
 	agent {
 		label 'migration'
 	}
-  
+
+	options {
+		timeout(time: 8, unit: 'HOURS')
+	}
+	
 	tools {
 		maven 'apache-maven-latest'
 		jdk 'openjdk-jdk17-latest'


### PR DESCRIPTION
Apply Jenkins/CI best practices and avoid builds hanging for days.