### PR TITLE
#2967 Relax Java line-ending policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,6 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
-# Explicitly declare text files you want to always be normalized and converted
-# to native line endings on checkout.
-*.java text
-
-
-# Declare files that will always have CRLF line endings on checkout.
-*.java text eol=crlf
-
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary


### PR DESCRIPTION
Fresh Linux and macOS clones start with hundreds of false modifications because Java files are forced to CRLF on checkout while many tracked Java blobs are stored with LF or mixed endings.

Remove the Java-specific CRLF rule and rely on the existing text=auto normalization policy so fresh clones stay clean without a repository-wide renormalization commit.