### PR TITLE
Bump to 7.1.0

### DIFF
--- a/common/features/org.polarsys.capella.common.feature/feature.xml
+++ b/common/features/org.polarsys.capella.common.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.common.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/common/features/org.polarsys.capella.common.feature/pom.xml
+++ b/common/features/org.polarsys.capella.common.feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.feature</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <properties>
     <!-- Skip feature modules in Sonar analysis -->

--- a/common/features/org.polarsys.capella.common.ui.feature/feature.xml
+++ b/common/features/org.polarsys.capella.common.ui.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.polarsys.capella.common.ui.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/common/features/org.polarsys.capella.common.ui.feature/pom.xml
+++ b/common/features/org.polarsys.capella.common.ui.feature/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.ui.feature</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <properties>
     <!-- Skip feature modules in Sonar analysis -->

--- a/common/features/org.polarsys.capella.common.ui.massactions.feature/feature.xml
+++ b/common/features/org.polarsys.capella.common.ui.massactions.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.common.ui.massactions.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/common/features/org.polarsys.capella.common.ui.massactions.feature/pom.xml
+++ b/common/features/org.polarsys.capella.common.ui.massactions.feature/pom.xml
@@ -12,12 +12,12 @@
 	<parent>
 		<groupId>org.polarsys</groupId>
 		<artifactId>org.polarsys.capella</artifactId>
-		<version>7.0.1-SNAPSHOT</version>
+		<version>7.1.0-SNAPSHOT</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 	<groupId>org.polarsys</groupId>
 	<artifactId>org.polarsys.capella.common.ui.massactions.feature</artifactId>
-	<version>7.0.1-SNAPSHOT</version>
+	<version>7.1.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 	<properties>
 		<!-- Skip feature modules in Sonar analysis -->

--- a/common/plugins/org.polarsys.capella.common.data.activity.gen.edit/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.data.activity.gen.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.data.activity.gen.edit; singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.polarsys.capella.common.data.activity.provider.ActivityEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/common/plugins/org.polarsys.capella.common.data.activity.gen.edit/pom.xml
+++ b/common/plugins/org.polarsys.capella.common.data.activity.gen.edit/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.data.activity.gen.edit</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/common/plugins/org.polarsys.capella.common.data.activity.gen/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.data.activity.gen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.data.activity.gen; singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/common/plugins/org.polarsys.capella.common.data.activity.gen/pom.xml
+++ b/common/plugins/org.polarsys.capella.common.data.activity.gen/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.data.activity.gen</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/common/plugins/org.polarsys.capella.common.data.behavior.gen.edit/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.data.behavior.gen.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.data.behavior.gen.edit; singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.polarsys.capella.common.data.behavior.provider.BehaviorEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/common/plugins/org.polarsys.capella.common.data.behavior.gen.edit/pom.xml
+++ b/common/plugins/org.polarsys.capella.common.data.behavior.gen.edit/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.data.behavior.gen.edit</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/common/plugins/org.polarsys.capella.common.data.behavior.gen/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.data.behavior.gen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.data.behavior.gen; singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/common/plugins/org.polarsys.capella.common.data.behavior.gen/pom.xml
+++ b/common/plugins/org.polarsys.capella.common.data.behavior.gen/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.data.behavior.gen</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/common/plugins/org.polarsys.capella.common.data.core.gen.edit/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.data.core.gen.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.data.core.gen.edit; singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.polarsys.capella.common.data.modellingcore.provider.ModellingCoreEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/common/plugins/org.polarsys.capella.common.data.core.gen.edit/pom.xml
+++ b/common/plugins/org.polarsys.capella.common.data.core.gen.edit/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.data.core.gen.edit</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/common/plugins/org.polarsys.capella.common.data.core.gen/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.data.core.gen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.data.core.gen; singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/common/plugins/org.polarsys.capella.common.data.core.gen/pom.xml
+++ b/common/plugins/org.polarsys.capella.common.data.core.gen/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.data.core.gen</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/common/plugins/org.polarsys.capella.common.data.helpers/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.data.helpers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.data.helpers;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.data.activity.gen;visibility:=reexport,
  org.polarsys.capella.common.data.behavior.gen;visibility:=reexport,

--- a/common/plugins/org.polarsys.capella.common.ef/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.ef/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.ef;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/common/plugins/org.polarsys.capella.common.flexibility.properties/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.flexibility.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.flexibility.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.flexibility.properties.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/common/plugins/org.polarsys.capella.common.flexibility.wizards/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.flexibility.wizards/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.flexibility.wizards;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.flexibility.wizards.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/common/plugins/org.polarsys.capella.common.helpers/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.helpers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.helpers;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.resources,
  org.polarsys.capella.common.platform.sirius.ted;visibility:=reexport,

--- a/common/plugins/org.polarsys.capella.common.id.handler/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.id.handler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.id.handler;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime,

--- a/common/plugins/org.polarsys.capella.common.libraries.gen.edit/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.libraries.gen.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.libraries.gen.edit;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.polarsys.capella.common.libraries.provider.LibrariesEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/common/plugins/org.polarsys.capella.common.libraries.gen.edit/pom.xml
+++ b/common/plugins/org.polarsys.capella.common.libraries.gen.edit/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.libraries.gen.edit</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/common/plugins/org.polarsys.capella.common.libraries.gen/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.libraries.gen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.libraries.gen;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/common/plugins/org.polarsys.capella.common.libraries.gen/pom.xml
+++ b/common/plugins/org.polarsys.capella.common.libraries.gen/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.libraries.gen</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/common/plugins/org.polarsys.capella.common.libraries/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.libraries/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.libraries;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.libraries.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/common/plugins/org.polarsys.capella.common.linkedtext.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.linkedtext.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.polarsys.capella.common.linkedtext.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.linkedtext.ui.LinkedTextUIActivator
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/common/plugins/org.polarsys.capella.common.menu.dynamic/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.menu.dynamic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.menu.dynamic;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.data.core.gen;visibility:=reexport,
  org.eclipse.ui.workbench

--- a/common/plugins/org.polarsys.capella.common.model.helpers/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.model.helpers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.model.helpers;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy

--- a/common/plugins/org.polarsys.capella.common.model/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.model;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Require-Bundle: org.eclipse.emf.edit;visibility:=reexport,
  org.polarsys.capella.common.helpers;visibility:=reexport,
  org.polarsys.capella.common.tools.report;visibility:=reexport

--- a/common/plugins/org.polarsys.capella.common.platform.eclipse.tools.report.console/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.platform.eclipse.tools.report.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.platform.eclipse.tools.report.console;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.platform.eclipse.tools.report.console.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/common/plugins/org.polarsys.capella.common.platform.eclipse.tools.report.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.platform.eclipse.tools.report.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.platform.eclipse.tools.report.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.platform.eclipse.tools.report.ui.ReportManagerUI
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.tools.report.ui,

--- a/common/plugins/org.polarsys.capella.common.platform.sirius.customization/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.platform.sirius.customization/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.platform.sirius.customization;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.platform.sirius.customisation.SiriusCustomizationPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/common/plugins/org.polarsys.capella.common.platform.sirius.ted/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.platform.sirius.ted/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.platform.sirius.ted;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Export-Package: org.polarsys.capella.common.platform.sirius.ted,
  org.polarsys.capella.common.platform.sirius.ted.property.testers

--- a/common/plugins/org.polarsys.capella.common.queries/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.queries/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.queries;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.queries.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.apache.commons.lang,

--- a/common/plugins/org.polarsys.capella.common.re.gen.edit/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.re.gen.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.re.gen.edit;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.polarsys.capella.common.re.provider.ReEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/common/plugins/org.polarsys.capella.common.re.gen.edit/pom.xml
+++ b/common/plugins/org.polarsys.capella.common.re.gen.edit/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.re.gen.edit</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/common/plugins/org.polarsys.capella.common.re.gen/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.re.gen/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.re.gen;singleton:=true
 Bundle-Vendor: %providerName
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,

--- a/common/plugins/org.polarsys.capella.common.re.gen/pom.xml
+++ b/common/plugins/org.polarsys.capella.common.re.gen/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.re.gen</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/common/plugins/org.polarsys.capella.common.re.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.re.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.re.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.re.ui.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/common/plugins/org.polarsys.capella.common.re/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.re/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.re;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.re.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/common/plugins/org.polarsys.capella.common.tools.report.appenders.console/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.tools.report.appenders.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.tools.report.appenders.console;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.tools.report.appenders.console.ConsoleAppenderActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.tools.report;visibility:=reexport,

--- a/common/plugins/org.polarsys.capella.common.tools.report.appenders.file/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.tools.report.appenders.file/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.tools.report.appenders.file;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.tools.report.appenders.file.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.tools.report;visibility:=reexport,

--- a/common/plugins/org.polarsys.capella.common.tools.report.appenders.reportlogview/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.tools.report.appenders.reportlogview/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.tools.report.appenders.reportlogview;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.debug.ui,

--- a/common/plugins/org.polarsys.capella.common.tools.report.appenders.usage.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.tools.report.appenders.usage.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.tools.report.appenders.usage.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.tools.report.appenders.usage.ui.UsageAppenderUIPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/common/plugins/org.polarsys.capella.common.tools.report.appenders.usage/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.tools.report.appenders.usage/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.tools.report.appenders.usage;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.tools.report.appenders.usage.UsageAppenderPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.tools.report;visibility:=reexport,

--- a/common/plugins/org.polarsys.capella.common.tools.report.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.tools.report.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.tools.report.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,
  org.polarsys.capella.common.tools.report;visibility:=reexport

--- a/common/plugins/org.polarsys.capella.common.tools.report/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.tools.report/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.tools.report;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.helpers;visibility:=reexport,
  org.apache.log4j;visibility:=reexport

--- a/common/plugins/org.polarsys.capella.common.transition/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.transition/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.transition;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.transition.common.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/common/plugins/org.polarsys.capella.common.ui.massactions.core/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.ui.massactions.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.ui.massactions.core;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.ui.massactions.core.activator.MECoreCapellaActivator
 Require-Bundle: org.polarsys.capella.core.ui.properties;visibility:=reexport,
  org.polarsys.capella.common.ui.toolkit.browser,

--- a/common/plugins/org.polarsys.capella.common.ui.massactions/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.ui.massactions/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.ui.massactions;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Require-Bundle: org.polarsys.kitalpha.massactions;visibility:=reexport,
  org.polarsys.capella.common.ui.massactions.core,
  org.eclipse.sirius.diagram.ui,

--- a/common/plugins/org.polarsys.capella.common.ui.menu.dynamic/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.ui.menu.dynamic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.ui.menu.dynamic;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui.navigator;visibility:=reexport,
  org.polarsys.capella.common.menu.dynamic;visibility:=reexport,

--- a/common/plugins/org.polarsys.capella.common.ui.services/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.ui.services/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.ui.services;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.data.core.gen;visibility:=reexport,
  org.eclipse.ui;visibility:=reexport,

--- a/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.ui.toolkit.browser;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.ui.toolkit.browser.BrowserActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/common/plugins/org.polarsys.capella.common.ui.toolkit/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.ui.toolkit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.ui.toolkit;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.ui.toolkit.ToolkitPlugin
 Bundle-Vendor: %providerName
 Export-Package: org.polarsys.capella.common.ui.toolkit,

--- a/common/plugins/org.polarsys.capella.common.ui/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/common/plugins/org.polarsys.capella.common/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.MdeCommonActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,

--- a/common/plugins/org.polarsys.capella.shared.id.handler/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.shared.id.handler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.shared.id.handler;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime,

--- a/common/plugins/pom.xml
+++ b/common/plugins/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>

--- a/core/features/org.polarsys.capella.core.advance.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.advance.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.advance.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName"
       plugin="org.polarsys.capella.core.platform.sirius.ui.perspective">
 

--- a/core/features/org.polarsys.capella.core.common.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.common.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.common.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.common.ui.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.common.ui.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.common.ui.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.compare.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.compare.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.compare.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.dashboard.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.dashboard.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.dashboard.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/core/features/org.polarsys.capella.core.git.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.git.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.git.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.libraries.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.libraries.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.libraries.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.migration.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.migration.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.migration.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/core/features/org.polarsys.capella.core.properties.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.properties.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.properties.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.properties.richtext.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.properties.richtext.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.properties.richtext.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.re.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.re.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.re.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.transfo.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.transfo.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.transfo.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.transition.common.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.transition.common.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.transition.common.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.transition.system.topdown.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.transition.system.topdown.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.transition.system.topdown.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.ui.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.ui.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.ui.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.ui.quickfix.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.ui.quickfix.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.ui.quickfix.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.ui.semantic.browser.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.ui.semantic.browser.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.ui.semantic.browser.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.ui.transfo.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.ui.transfo.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.ui.transfo.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.ui.wizards.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.ui.wizards.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.ui.wizards.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/org.polarsys.capella.core.validation.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.validation.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.validation.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/core/features/pom.xml
+++ b/core/features/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>

--- a/core/plugins/org.polarsys.capella.common.ui.resources/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.common.ui.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.ui.resources;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.common.ui.resources.ResourcePlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.af.integration.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.af.integration.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.polarsys.capella.core.af.integration.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.af.integration.ui.AFIntegrationUIPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy 

--- a/core/plugins/org.polarsys.capella.core.af.integration/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.af.integration/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.polarsys.capella.core.af.integration;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.af.integration.AFIntegrationPlugin
 Require-Bundle: org.polarsys.capella.core.model.handler,
  org.polarsys.kitalpha.ad.metadata;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.application/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.application;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.application.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.polarsys.capella.common.mdsofa.common

--- a/core/plugins/org.polarsys.capella.core.commandline.core.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.commandline.core.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.commandline.core.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.commandline.core/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.commandline.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.commandline.core;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.tools.report;visibility:=reexport,
  org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.compare/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.compare/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.compare;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.compare.CapellaComparePlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.data.business.queries/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.business.queries/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.business.queries;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.model.helpers;visibility:=reexport,
  org.polarsys.capella.core.model.preferences;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.data.common.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.common.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.common.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.common.properties.CommonPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.core.properties;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.data.common.ui.quickfix/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.common.ui.quickfix/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.common.ui.quickfix;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation.ui,

--- a/core/plugins/org.polarsys.capella.core.data.common.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.common.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.common.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation,

--- a/core/plugins/org.polarsys.capella.core.data.core.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.core.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.core.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.core.properties.CorePropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.ui.properties;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.data.core.ui.quickfix/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.core.ui.quickfix/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.core.ui.quickfix;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.core.ui.quickfix.CoreQuickFixActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.resources,

--- a/core/plugins/org.polarsys.capella.core.data.core.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.core.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.core.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation,

--- a/core/plugins/org.polarsys.capella.core.data.cs.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.cs.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.cs.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.cs.properties.CsPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.information.communication.properties;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.data.cs.ui.quickfix/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.cs.ui.quickfix/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.cs.ui.quickfix;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.cs.ui.quickfix.CsQuickFixActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.resources,

--- a/core/plugins/org.polarsys.capella.core.data.cs.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.cs.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.cs.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.data.business.queries,

--- a/core/plugins/org.polarsys.capella.core.data.ctx.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.ctx.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.ctx.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.ctx.properties.CtxPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.fa.properties;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.data.ctx.ui.quickfix/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.ctx.ui.quickfix/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.ctx.ui.quickfix;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.ctx.ui.quickfix.CtxQuickFixActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.validation.ui.ide,

--- a/core/plugins/org.polarsys.capella.core.data.ctx.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.ctx.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.ctx.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation,

--- a/core/plugins/org.polarsys.capella.core.data.epbs.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.epbs.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.epbs.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.epbs.properties.EPBSPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.cs.properties;visibility:=reexport

--- a/core/plugins/org.polarsys.capella.core.data.epbs.ui.quickfix/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.epbs.ui.quickfix/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.epbs.ui.quickfix;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.epbs.ui.quickfix.EpbsQuickFixActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.validation.ui.ide,

--- a/core/plugins/org.polarsys.capella.core.data.epbs.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.epbs.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.epbs.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation

--- a/core/plugins/org.polarsys.capella.core.data.fa.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.fa.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.fa.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.fa.properties.FaPropertiesPlugin
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy

--- a/core/plugins/org.polarsys.capella.core.data.fa.ui.quickfix/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.fa.ui.quickfix/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.fa.ui.quickfix;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.fa.ui.quickfix.FaQuickFixActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.resources,

--- a/core/plugins/org.polarsys.capella.core.data.fa.ui.wizards/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.fa.ui.wizards/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.fa.ui.wizards;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.fa.ui.wizards.FAUIWizardsPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.data.fa.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.fa.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.fa.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation,

--- a/core/plugins/org.polarsys.capella.core.data.gen.edit.decorators/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.gen.edit.decorators/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.gen.edit.decorators;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.data.gen.edit;visibility:=reexport,
  org.polarsys.capella.core.model.handler,

--- a/core/plugins/org.polarsys.capella.core.data.gen.edit/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.gen.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.gen.edit; singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.polarsys.capella.core.data.capellamodeller.provider.CapellaModellerEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/core/plugins/org.polarsys.capella.core.data.gen.edit/pom.xml
+++ b/core/plugins/org.polarsys.capella.core.data.gen.edit/pom.xml
@@ -17,13 +17,13 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella.core.plugins</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
   <properties>
     <sonar.skip>true</sonar.skip>
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.core.data.gen.edit</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/core/plugins/org.polarsys.capella.core.data.gen.editor/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.gen.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.gen.editor; singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.polarsys.capella.core.data.capellamodeller.presentation.CapellaModellerEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/core/plugins/org.polarsys.capella.core.data.gen.editor/pom.xml
+++ b/core/plugins/org.polarsys.capella.core.data.gen.editor/pom.xml
@@ -17,13 +17,13 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella.core.plugins</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
   <properties>
     <sonar.skip>true</sonar.skip>
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.core.data.gen.editor</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/core/plugins/org.polarsys.capella.core.data.gen/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.gen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.gen; singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.core.data.gen/pom.xml
+++ b/core/plugins/org.polarsys.capella.core.data.gen/pom.xml
@@ -17,13 +17,13 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella.core.plugins</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
   <properties>
     <sonar.skip>true</sonar.skip>
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.core.data.gen</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/core/plugins/org.polarsys.capella.core.data.helpers/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.helpers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.helpers;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Export-Package: org.polarsys.capella.core.data.helpers.capellacommon,
  org.polarsys.capella.core.data.helpers.capellacommon.delegates,

--- a/core/plugins/org.polarsys.capella.core.data.information.communication.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.information.communication.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.information.communication.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.information.communication.properties.CommunicationPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.core.properties;visibility:=reexport

--- a/core/plugins/org.polarsys.capella.core.data.information.communication.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.information.communication.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.information.communication.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation

--- a/core/plugins/org.polarsys.capella.core.data.information.datatype.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.information.datatype.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.information.datatype.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.information.datatype.properties.DataTypePropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.information.properties;visibility:=reexport

--- a/core/plugins/org.polarsys.capella.core.data.information.datatype.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.information.datatype.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.information.datatype.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation

--- a/core/plugins/org.polarsys.capella.core.data.information.datavalue.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.information.datavalue.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.information.datavalue.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.information.datavalue.properties.DataValuePropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.information.properties;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.data.information.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.information.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.information.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.information.properties.InformationPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.common.properties;visibility:=reexport

--- a/core/plugins/org.polarsys.capella.core.data.information.ui.quickfix/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.information.ui.quickfix/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.information.ui.quickfix;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.information.ui.quickfix.InformationQuickFixActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.data.information.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.information.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.information.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation,

--- a/core/plugins/org.polarsys.capella.core.data.interaction.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.interaction.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.interaction.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.interaction.properties.InteractionPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.information.properties;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.data.interaction.ui.quickfix/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.interaction.ui.quickfix/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.interaction.ui.quickfix;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.interaction.ui.quickfix.InteractionQuickFixActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.ui,

--- a/core/plugins/org.polarsys.capella.core.data.interaction.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.interaction.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.interaction.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation,

--- a/core/plugins/org.polarsys.capella.core.data.la.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.la.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.la.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.la.properties.LaPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.fa.properties;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.data.la.ui.quickfix/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.la.ui.quickfix/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.la.ui.quickfix;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.la.ui.quickfix.LaQuickFixActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.validation.ui.ide,

--- a/core/plugins/org.polarsys.capella.core.data.la.ui.wizards/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.la.ui.wizards/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.polarsys.capella.core.ui.toolkit,
  org.polarsys.capella.core.data.gen,
  org.eclipse.sirius.diagram,
  org.polarsys.capella.core.model.handler
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.polarsys.capella.core.common.ui.wizards.LCDWizardPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/core/plugins/org.polarsys.capella.core.data.la.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.la.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.la.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation

--- a/core/plugins/org.polarsys.capella.core.data.menu.contributions/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.menu.contributions/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.menu.contributions;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.menu.dynamic,

--- a/core/plugins/org.polarsys.capella.core.data.migration/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.migration/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.migration;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.migration.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.data.modeller.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.modeller.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.modeller.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.modeller.properties.ModellerPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.core.properties;visibility:=reexport

--- a/core/plugins/org.polarsys.capella.core.data.oa.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.oa.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.oa.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.oa.properties.OaPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.fa.properties;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.data.oa.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.oa.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.oa.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation

--- a/core/plugins/org.polarsys.capella.core.data.pa.deployment.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.pa.deployment.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.pa.deployment.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.pa.deployment.properties.DeploymentPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.core.properties;visibility:=reexport

--- a/core/plugins/org.polarsys.capella.core.data.pa.deployment.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.pa.deployment.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.pa.deployment.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation

--- a/core/plugins/org.polarsys.capella.core.data.pa.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.pa.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.pa.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.pa.properties.PaPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.cs.properties;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.data.pa.ui.quickfix/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.pa.ui.quickfix/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.pa.ui.quickfix;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.pa.ui.quickfix.PaQuickFixActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.validation.ui.ide,

--- a/core/plugins/org.polarsys.capella.core.data.pa.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.pa.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.pa.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation,

--- a/core/plugins/org.polarsys.capella.core.data.res.edit/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.res.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.res.edit
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.polarsys.capella.core.data.gen.edit
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.core.data.res.edit/pom.xml
+++ b/core/plugins/org.polarsys.capella.core.data.res.edit/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella.core.plugins</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.core.data.res.edit</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <sonar.skip>true</sonar.skip>

--- a/core/plugins/org.polarsys.capella.core.data.res.editor/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.res.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.res.editor
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.polarsys.capella.core.data.gen.editor;bundle-version="0.0.0"
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.core.data.res.editor/pom.xml
+++ b/core/plugins/org.polarsys.capella.core.data.res.editor/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella.core.plugins</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.core.data.res.editor</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <sonar.skip>true</sonar.skip>

--- a/core/plugins/org.polarsys.capella.core.data.selection.queries/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.selection.queries/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.selection.queries;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.model.helpers;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.data.sharedmodel.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.data.sharedmodel.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.sharedmodel.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.data.sharedmodel.properties.SharedModelPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.core.properties;visibility:=reexport

--- a/core/plugins/org.polarsys.capella.core.diagram.helpers/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.diagram.helpers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.diagram.helpers;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.model.helpers;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.explorer.activity.ui.richtext/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.explorer.activity.ui.richtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.explorer.activity.ui.richtext;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.explorer.activity.ui.richtext.CapellaActivityExplorerRichTextActivator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.views.properties.tabbed,

--- a/core/plugins/org.polarsys.capella.core.explorer.activity.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.explorer.activity.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.explorer.activity.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.explorer.activity.ui.CapellaActivityExplorerActivator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.flexibility.wizards/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.flexibility.wizards/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.flexibility.wizards;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.flexibility.wizards.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.libraries.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.libraries.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.libraries.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.libraries.ui.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.expressions,

--- a/core/plugins/org.polarsys.capella.core.libraries/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.libraries/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.libraries;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.libraries.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.flexibility.properties,

--- a/core/plugins/org.polarsys.capella.core.linkedtext.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.linkedtext.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.linkedtext.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.linkedtext.ui.CapellaLinkedTextUIActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.menu.dynamic/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.menu.dynamic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.menu.dynamic;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.ui.menu.dynamic;visibility:=reexport,
  org.polarsys.capella.core.model.skeleton;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.model.detachement/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.model.detachement/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.model.detachement;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.model.detachement.CapellaModelDetachementPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.forms,

--- a/core/plugins/org.polarsys.capella.core.model.handler/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.model.handler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.model.handler;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: com.google.guava,
  org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.model.helpers/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.model.helpers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.model.helpers;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.apache.commons.lang,
  org.eclipse.emf.codegen.ecore,

--- a/core/plugins/org.polarsys.capella.core.model.links.helpers/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.model.links.helpers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.model.links.helpers
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.sirius.analysis;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.model.obfuscator/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.model.obfuscator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.model.obfuscator;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/core/plugins/org.polarsys.capella.core.model.preferences/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.model.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.model.preferences;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.model.preferences.CapellaModelPreferencesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.model.semantic/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.model.semantic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.model.semantic;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.model.semantic.internal.SemanticModelActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.model.skeleton/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.model.skeleton/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.model.skeleton;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.data.gen,

--- a/core/plugins/org.polarsys.capella.core.platform.eclipse.ui.trace/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.eclipse.ui.trace/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.platform.eclipse.ui.trace;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.adapter/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.adapter/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.platform.sirius.adapter;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.platform.sirius.adapter.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.sirius.diagram;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.clipboard/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.clipboard/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.platform.sirius.clipboard;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.platform.sirius.clipboard.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.sirius.diagram.sequence,

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.platform.sirius.sirius.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.validation,

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.actions/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.actions/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.platform.sirius.ui.actions;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: com.google.guava,

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.menu/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.menu/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.platform.sirius.ui.menu;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.sirius.diagram,
  org.eclipse.gmf.runtime.diagram.ui.resources.editor;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.platform.sirius.ui.navigator;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.platform.sirius.ui.navigator.CapellaNavigatorPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.perspective/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.perspective/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.platform.sirius.ui.perspective;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.platform.sirius.ui.PerspectivePlugin
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.project/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.project/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.platform.sirius.ui.project;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.platform.sirius.ui.project.CapellaProjectActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.services/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.services/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.platform.sirius.ui.services;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.data.gen,
  org.polarsys.capella.core.platform.sirius.ui.perspective,

--- a/core/plugins/org.polarsys.capella.core.preferences.project.configuration/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.preferences.project.configuration/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.preferences.project.configuration;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.resources,

--- a/core/plugins/org.polarsys.capella.core.preferences/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.preferences;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.preferences.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.expressions,

--- a/core/plugins/org.polarsys.capella.core.projection.common.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.projection.common.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.projection.common.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.tiger;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.projection.common/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.projection.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.projection.common;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.core.model.helpers,

--- a/core/plugins/org.polarsys.capella.core.projection.exchanges/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.projection.exchanges/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.projection.exchanges;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.projection.exchanges.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.projection.interfaces/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.projection.interfaces/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.projection.interfaces;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Export-Package: org.polarsys.capella.core.projection.interfaces,
  org.polarsys.capella.core.projection.interfaces.generateInterfaces,

--- a/core/plugins/org.polarsys.capella.core.projection.scenario/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.projection.scenario/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.projection.scenario;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.projection.scenario.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.re.project/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.re.project/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.re.project;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.re.project.ReProjectActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.osgi,

--- a/core/plugins/org.polarsys.capella.core.re.ui.quickfix/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.re.ui.quickfix/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.re.ui.quickfix;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.re.ui.quickfix.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.re.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.re.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.re.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.re.ui.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.re.updateconnections.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.re.updateconnections.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.re.updateconnections.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.re.updateconnections.ui.UpdateConnectionsUIActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.re.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.re.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.re.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.common.re,

--- a/core/plugins/org.polarsys.capella.core.re/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.re/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.re;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.re.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.semantic.queries;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.semantic.queries.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.model.handler,

--- a/core/plugins/org.polarsys.capella.core.services/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.services/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.services;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.resources;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.polarsys.capella.core.sirius.analysis;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.sirius.analysis.activator.SiriusViewActivator
 Export-Package: org.polarsys.capella.core.sequencediag,
  org.polarsys.capella.core.sequencediag.datas,

--- a/core/plugins/org.polarsys.capella.core.sirius.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.sirius.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.sirius.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.core.tiger/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.tiger/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.tiger;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.common;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.transition.common.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.transition.common.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.transition.common.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.transition.common.ui.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.transition.diagram.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.transition.diagram.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.transition.diagram.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.transition.diagram.ui.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.transition.diagram/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.transition.diagram/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.transition.diagram;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.transition.diagram.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.transition.system.topdown.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.transition.system.topdown.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.transition.system.topdown.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.transition.system.topdown.ui.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.transition.system.topdown/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.transition.system.topdown/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.transition.system.topdown;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.transition.system.topdown.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.transition.system.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.transition.system.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.transition.system.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.transition.system.ui.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.transition.system/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.transition.system/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.transition.system;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.transition.system.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.ui.fastlinker/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.fastlinker/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.fastlinker;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.ui.fastlinker.FastLinkerActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.model.links.helpers;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.ui.metric/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.metric/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.metric;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.ui.metric.MetricActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.core.ui.properties.descriptions/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.properties.descriptions/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.properties.descriptions;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.sirius.diagram.ui,

--- a/core/plugins/org.polarsys.capella.core.ui.properties.richtext/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.properties.richtext/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.properties.richtext;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.sirius.diagram.ui,

--- a/core/plugins/org.polarsys.capella.core.ui.properties/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.properties/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.properties;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.ui.properties.CapellaUIPropertiesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.ui.toolkit;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.ui.reportlog/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.reportlog/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.reportlog;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.ui.reportlog.ReportLogActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.core.ui.resources/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.resources
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.ui.resources.CapellaUIResourcesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.ui.resources/icons/full/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.resources/icons/full/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.resources
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.ui.resources.CapellaUIResourcesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/core/plugins/org.polarsys.capella.core.ui.search/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.search;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.ui.search.Activator
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/core/plugins/org.polarsys.capella.core.ui.semantic.browser.sirius/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.semantic.browser.sirius/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.semantic.browser.sirius;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.ui.semantic.browser.sirius.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.core.ui.semantic.browser;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.ui.semantic.browser/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.semantic.browser/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.semantic.browser;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.ui.semantic.browser.CapellaBrowserActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.core.ui.toolkit/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.toolkit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.toolkit;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.common.ui.toolkit;visibility:=reexport,
  org.polarsys.capella.common.ui.resources;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.validation.commandline/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.validation.commandline/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.validation.commandline;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.validation.commandline.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.validation.ui.ide/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.validation.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.validation.ui.ide;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.validation.ui.ide.PluginActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui;visibility:=reexport,

--- a/core/plugins/org.polarsys.capella.core.validation.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.validation.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.validation.ui;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.validation.ui.CapellaValidationUIActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/core/plugins/org.polarsys.capella.core.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.validation;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.ui.views/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.ui.views/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.polarsys.capella.ui.views
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Fragment-Host: org.eclipse.ui.views;bundle-version="3.2.101"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.ui.views/pom.xml
+++ b/core/plugins/org.polarsys.capella.ui.views/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella.core.plugins</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.ui.views</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <sonar.skip>true</sonar.skip>

--- a/core/plugins/pom.xml
+++ b/core/plugins/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>

--- a/doc/features/org.polarsys.capella.doc.feature/feature.xml
+++ b/doc/features/org.polarsys.capella.doc.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.doc.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/doc/features/org.polarsys.capella.doc.feature/pom.xml
+++ b/doc/features/org.polarsys.capella.doc.feature/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.doc.feature</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <properties>
     <!-- Skip feature modules in Sonar analysis -->

--- a/doc/plugins/org.polarsys.capella.commandline.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.commandline.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.commandline.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.commandline.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.common.ui.massactions.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.common.ui.massactions.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.ui.massactions.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.help
 Automatic-Module-Name: org.polarsys.capella.common.ui.massactions.doc

--- a/doc/plugins/org.polarsys.capella.core.re.updateconnections.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.core.re.updateconnections.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.re.updateconnections.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/doc/plugins/org.polarsys.capella.core.ui.intro/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.core.ui.intro/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.ui.intro;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Export-Package: org.polarsys.capella.core.ui.intro.views
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/doc/plugins/org.polarsys.capella.developer.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.developer.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.developer.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.developer.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.developer.doc/pom.xml
+++ b/doc/plugins/org.polarsys.capella.developer.doc/pom.xml
@@ -17,11 +17,11 @@
 	<parent>
 		<groupId>org.polarsys</groupId>
 		<artifactId>org.polarsys.capella.doc.plugins</artifactId>
-		<version>7.0.1-SNAPSHOT</version>
+		<version>7.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.polarsys</groupId>
 	<artifactId>org.polarsys.capella.developer.doc</artifactId>
-	<version>7.0.1-SNAPSHOT</version>
+	<version>7.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/doc/plugins/org.polarsys.capella.diagrams.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.diagrams.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.diagrams.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.diagrams.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.diffmerge.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.diffmerge.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.diffmerge.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.diffmerge.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.doc/html/Release note/API_6.x_to_7.x.html
+++ b/doc/plugins/org.polarsys.capella.doc/html/Release note/API_6.x_to_7.x.html
@@ -1201,5 +1201,7 @@
 				<img width="8" border="0" src="../Images/over_co.png"/> <code>org.polarsys.capella.core.ui.semantic.browser.label.provider.SemanticBrowserDecoratingLabelProvider.getText(Object)</code>
 			</li>
 		</ul>
+		<h2 id="Raw_API_changes_from_7.0.1_to_7.1.0">Raw API changes from 7.0.1 to 7.1.0</h2>
+		
 	</body>
 </html>

--- a/doc/plugins/org.polarsys.capella.doc/html/Release note/API_6.x_to_7.x.mediawiki
+++ b/doc/plugins/org.polarsys.capella.doc/html/Release note/API_6.x_to_7.x.mediawiki
@@ -447,3 +447,5 @@ Models from previous versions and from 7.0.0 have to be migrated.
 
 ==== Changes in <code>org.polarsys.capella.core.ui.semantic.browser</code>====
 * <span class="labels"><span class="label label-success">Added</span></span>[[File:../Images/methpub_obj.png|16px]][[File:../Images/over_co.png|8px]] <code>org.polarsys.capella.core.ui.semantic.browser.label.provider.SemanticBrowserDecoratingLabelProvider.getText(Object)</code>
+
+== Raw API changes from 7.0.1 to 7.1.0 ==

--- a/doc/plugins/org.polarsys.capella.doc/toc.xml
+++ b/doc/plugins/org.polarsys.capella.doc/toc.xml
@@ -34,6 +34,8 @@
             </topic>
             <topic href="html/Release note/API_6.x_to_7.x.html#Raw_API_changes_from_7.0.0_to_7.0.1" label="Raw API changes from 7.0.0 to 7.0.1">
             </topic>
+            <topic href="html/Release note/API_6.x_to_7.x.html#Raw_API_changes_from_7.0.1_to_7.1.0" label="Raw API changes from 7.0.1 to 7.1.0">
+            </topic>
          </topic>
          <topic href="html/Release note/API_5.x_to_6.x.html" label="Capella 5.x to 6.x">
             <topic href="html/Release note/API_5.x_to_6.x.html#Major_changes" label="Major changes">

--- a/doc/plugins/org.polarsys.capella.git.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.git.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.git.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/doc/plugins/org.polarsys.capella.glossary.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.glossary.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.glossary.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.glossary.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.preferences.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.preferences.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.preferences.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.preferences.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.properties.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.properties.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.properties.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.properties.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.re.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.re.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.re.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.re.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.th.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.th.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.th.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.th.doc.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/doc/plugins/org.polarsys.capella.tipsandtricks.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.tipsandtricks.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.tipsandtricks.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.tipsandtricks.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.transitions.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.transitions.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.transitions.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.transitions.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.ui.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.ui.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.ui.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.ui.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.ui.doc/html/Installation Guide/How to install Capella and Addons.html
+++ b/doc/plugins/org.polarsys.capella.ui.doc/html/Installation Guide/How to install Capella and Addons.html
@@ -395,10 +395,10 @@
 			<a href="https://support.microsoft.com/en-us/help/2999226/update-for-universal-c-runtime-in-windows" target="_blank">https://support.microsoft.com/en-us/help/2999226/update-for-universal-c-runtime-in-windows</a>
 		</p>
 		<h2 id="Workaround_to_open_the_Help_Content_when_there_is_problem_with_the_browser">Workaround to open the Help Content when there is problem with the browser</h2>
-		<p>Sometimes due to security policy, the web browser has problem on opening local host web pages. This is the case of the Help Content page when it is accessed via the <code>127.0.1.1</code> IP address. </p>
+		<p>Sometimes due to security policy, the web browser has problem on opening local host web pages. This is the case of the Help Content page when it is accessed via the <code>127.0.0.1</code> IP address. </p>
 		<p>Here are 2 possible workarounds to overcome this problem:</p>
 		<ul>
-			<li>In the URL, replace <code>127.0.1.1</code> by <code>localhost</code>.</li>
+			<li>In the URL, replace <code>127.0.0.1</code> by <code>localhost</code>.</li>
 			<li>Copy the URL and paste it in another web browser without restriction.</li>
 		</ul>
 		<h1 id="Uninstallation">Uninstallation</h1>

--- a/doc/plugins/org.polarsys.capella.ui.doc/html/Installation Guide/How to install Capella and Addons.mediawiki
+++ b/doc/plugins/org.polarsys.capella.ui.doc/html/Installation Guide/How to install Capella and Addons.mediawiki
@@ -306,11 +306,11 @@ If launching Capella in Windows OS ends up with the following pop-up, it means t
 The solution is to install this Microsoft's update according to your OS version: https://support.microsoft.com/en-us/help/2999226/update-for-universal-c-runtime-in-windows
 
 == Workaround to open the Help Content when there is problem with the browser ==
-Sometimes due to security policy, the web browser has problem on opening local host web pages. This is the case of the Help Content page when it is accessed via the <code>127.0.1.1</code> IP address. 
+Sometimes due to security policy, the web browser has problem on opening local host web pages. This is the case of the Help Content page when it is accessed via the <code>127.0.0.1</code> IP address. 
 
 Here are 2 possible workarounds to overcome this problem:
 
-* In the URL, replace <code>127.0.1.1</code> by <code>localhost</code>.
+* In the URL, replace <code>127.0.0.1</code> by <code>localhost</code>.
 * Copy the URL and paste it in another web browser without restriction.
 
 = Uninstallation =

--- a/doc/plugins/org.polarsys.capella.validation.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.validation.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.validation.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.validation.doc.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,

--- a/doc/plugins/org.polarsys.capella.viewpoint.doc/META-INF/MANIFEST.MF
+++ b/doc/plugins/org.polarsys.capella.viewpoint.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.viewpoint.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: 

--- a/doc/plugins/pom.xml
+++ b/doc/plugins/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>

--- a/ext/detachment/features/org.polarsys.capella.detachment.feature/feature.xml
+++ b/ext/detachment/features/org.polarsys.capella.detachment.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.detachment.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <copyright>

--- a/ext/detachment/features/org.polarsys.capella.detachment.feature/pom.xml
+++ b/ext/detachment/features/org.polarsys.capella.detachment.feature/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.detachment.feature</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <properties>
     <!-- Skip feature modules in Sonar analysis -->

--- a/ext/detachment/plugins/org.polarsys.capella.detachment.propertyvalue/META-INF/MANIFEST.MF
+++ b/ext/detachment/plugins/org.polarsys.capella.detachment.propertyvalue/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.detachment.propertyvalue;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.detachment.propertyvalue.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/ext/detachment/plugins/org.polarsys.capella.detachment.propertyvalue/pom.xml
+++ b/ext/detachment/plugins/org.polarsys.capella.detachment.propertyvalue/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.detachment.propertyvalue</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/ext/detachment/plugins/org.polarsys.capella.detachment.version.precondition/META-INF/MANIFEST.MF
+++ b/ext/detachment/plugins/org.polarsys.capella.detachment.version.precondition/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.detachment.version.precondition;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.detachment.version.precondition.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/ext/detachment/plugins/org.polarsys.capella.detachment.version.precondition/pom.xml
+++ b/ext/detachment/plugins/org.polarsys.capella.detachment.version.precondition/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.detachment.version.precondition</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/ext/elk/features/org.polarsys.capella.core.sirius.elk.feature/feature.xml
+++ b/ext/elk/features/org.polarsys.capella.core.sirius.elk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.polarsys.capella.core.sirius.elk.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/ext/elk/features/org.polarsys.capella.core.sirius.elk.feature/pom.xml
+++ b/ext/elk/features/org.polarsys.capella.core.sirius.elk.feature/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../../</relativePath>
   </parent>
 

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk.doc/META-INF/MANIFEST.MF
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.sirius.elk.doc;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui
 Automatic-Module-Name: org.polarsys.capella.core.sirius.elk.doc

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk.doc/pom.xml
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk.doc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../../</relativePath>
   </parent>
 

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/META-INF/MANIFEST.MF
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.sirius.elk;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.sirius.diagram.ui;bundle-version="7.4.0",
  org.eclipse.gmf.runtime.diagram.ui;bundle-version="1.9.0",
@@ -22,5 +22,5 @@ Require-Bundle: org.eclipse.sirius.diagram.ui;bundle-version="7.4.0",
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin
 Automatic-Module-Name: org.polarsys.capella.core.sirius.elk
-Export-Package: org.polarsys.capella.core.sirius.elk;version="7.0.1";x-internal:=true,
+Export-Package: org.polarsys.capella.core.sirius.elk;version="7.1.0";x-internal:=true,
  org.polarsys.capella.core.sirius.elk.properties;version="1.5.0";x-internal:=true

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/pom.xml
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../../</relativePath>
   </parent>
 

--- a/ext/viatra/features/org.polarsys.capella.viatra.core.feature/feature.xml
+++ b/ext/viatra/features/org.polarsys.capella.viatra.core.feature/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="org.polarsys.capella.viatra.core.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/ext/viatra/features/org.polarsys.capella.viatra.core.feature/pom.xml
+++ b/ext/viatra/features/org.polarsys.capella.viatra.core.feature/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.viatra.core.feature</artifactId>  
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <properties>
     <!-- Skip feature modules in Sonar analysis -->

--- a/ext/viatra/plugins/org.polarsys.capella.viatra.common.data.gen/META-INF/MANIFEST.MF
+++ b/ext/viatra/plugins/org.polarsys.capella.viatra.common.data.gen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.viatra.common.data.gen;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Export-Package: org.polarsys.capella.viatra.common.data.activity.surrogate,
  org.polarsys.capella.viatra.common.data.core.surrogate

--- a/ext/viatra/plugins/org.polarsys.capella.viatra.common.data.gen/pom.xml
+++ b/ext/viatra/plugins/org.polarsys.capella.viatra.common.data.gen/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.viatra.common.data.gen</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/ext/viatra/plugins/org.polarsys.capella.viatra.common.re.gen/META-INF/MANIFEST.MF
+++ b/ext/viatra/plugins/org.polarsys.capella.viatra.common.re.gen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.viatra.common.re.gen;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Export-Package: org.polarsys.capella.viatra.common.re.surrogate
 Require-Bundle: org.polarsys.capella.common.re.gen,

--- a/ext/viatra/plugins/org.polarsys.capella.viatra.common.re.gen/pom.xml
+++ b/ext/viatra/plugins/org.polarsys.capella.viatra.common.re.gen/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.viatra.common.re.gen</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/ext/viatra/plugins/org.polarsys.capella.viatra.core.data.gen/META-INF/MANIFEST.MF
+++ b/ext/viatra/plugins/org.polarsys.capella.viatra.core.data.gen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.viatra.core.data.gen;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Export-Package: org.polarsys.capella.viatra.core.data.capellacommon.surrogate,
  org.polarsys.capella.viatra.core.data.capellacore.surrogate,

--- a/ext/viatra/plugins/org.polarsys.capella.viatra.core.data.gen/pom.xml
+++ b/ext/viatra/plugins/org.polarsys.capella.viatra.core.data.gen/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.viatra.core.data.gen</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/legacy/plugins/org.polarsys.capella.common.mdsofa.common/META-INF/MANIFEST.MF
+++ b/legacy/plugins/org.polarsys.capella.common.mdsofa.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.mdsofa.common;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.resources;visibility:=reexport,
  org.eclipse.core.runtime;visibility:=reexport,

--- a/legacy/plugins/org.polarsys.capella.common.mdsofa.common/pom.xml
+++ b/legacy/plugins/org.polarsys.capella.common.mdsofa.common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.mdsofa.common</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/m2/features/org.polarsys.capella.core.model.definition.feature/feature.xml
+++ b/m2/features/org.polarsys.capella.core.model.definition.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.model.definition.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/m2/features/org.polarsys.capella.core.model.definition.feature/pom.xml
+++ b/m2/features/org.polarsys.capella.core.model.definition.feature/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.core.model.definition.feature</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/m2/plugins/org.polarsys.capella.common.data.def/META-INF/MANIFEST.MF
+++ b/m2/plugins/org.polarsys.capella.common.data.def/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.data.def; singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin

--- a/m2/plugins/org.polarsys.capella.common.data.def/pom.xml
+++ b/m2/plugins/org.polarsys.capella.common.data.def/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.common.data.def</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/m2/plugins/org.polarsys.capella.core.data.def/META-INF/MANIFEST.MF
+++ b/m2/plugins/org.polarsys.capella.core.data.def/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.def;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin

--- a/m2/plugins/org.polarsys.capella.core.data.def/pom.xml
+++ b/m2/plugins/org.polarsys.capella.core.data.def/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.core.data.def</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<name>Capella</name>
 	<groupId>org.polarsys</groupId>
 	<artifactId>org.polarsys.capella</artifactId>
-	<version>7.0.1-SNAPSHOT</version>
+	<version>7.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -75,7 +75,7 @@
 						<artifact>
 							<groupId>org.polarsys</groupId>
 							<artifactId>org.polarsys.capella</artifactId>
-							<version>7.0.1-SNAPSHOT</version>
+							<version>7.1.0-SNAPSHOT</version>
 							<classifier>releng/plugins/org.polarsys.capella.targets/${target-platform-path}/capella.target-definition</classifier>
 						</artifact>
 					</target>

--- a/releng/cdo/features/org.polarsys.capella.cdo.mock.feature/feature.xml
+++ b/releng/cdo/features/org.polarsys.capella.cdo.mock.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.cdo.mock.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <copyright url="%licenseURL">

--- a/releng/cdo/features/pom.xml
+++ b/releng/cdo/features/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>

--- a/releng/cdo/plugins/org.polarsys.capella.common.data.activity.gen.cdo/META-INF/MANIFEST.MF
+++ b/releng/cdo/plugins/org.polarsys.capella.common.data.activity.gen.cdo/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.data.activity.gen.cdo
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
  org.polarsys.capella.common.data.activity.gen;visibility:=reexport

--- a/releng/cdo/plugins/org.polarsys.capella.common.data.behavior.gen.cdo/META-INF/MANIFEST.MF
+++ b/releng/cdo/plugins/org.polarsys.capella.common.data.behavior.gen.cdo/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.data.behavior.gen.cdo
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
  org.polarsys.capella.common.data.behavior.gen;visibility:=reexport

--- a/releng/cdo/plugins/org.polarsys.capella.common.data.core.gen.cdo/META-INF/MANIFEST.MF
+++ b/releng/cdo/plugins/org.polarsys.capella.common.data.core.gen.cdo/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.data.core.gen.cdo
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
  org.polarsys.capella.common.data.core.gen;visibility:=reexport

--- a/releng/cdo/plugins/org.polarsys.capella.common.libraries.gen.cdo/META-INF/MANIFEST.MF
+++ b/releng/cdo/plugins/org.polarsys.capella.common.libraries.gen.cdo/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.libraries.gen.cdo
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
  org.polarsys.capella.common.libraries.gen;visibility:=reexport

--- a/releng/cdo/plugins/org.polarsys.capella.common.re.gen.cdo/META-INF/MANIFEST.MF
+++ b/releng/cdo/plugins/org.polarsys.capella.common.re.gen.cdo/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.common.re.gen.cdo
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
  org.polarsys.capella.common.re.gen;visibility:=reexport

--- a/releng/cdo/plugins/org.polarsys.capella.core.data.gen.cdo/META-INF/MANIFEST.MF
+++ b/releng/cdo/plugins/org.polarsys.capella.core.data.gen.cdo/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.core.data.gen.cdo
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
  org.polarsys.capella.core.data.gen;visibility:=reexport

--- a/releng/cdo/plugins/org.polarsys.kitalpha.ad.metadata.model.cdo/META-INF/MANIFEST.MF
+++ b/releng/cdo/plugins/org.polarsys.kitalpha.ad.metadata.model.cdo/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.kitalpha.ad.metadata.model.cdo
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
  org.polarsys.kitalpha.ad.metadata.model;visibility:=reexport

--- a/releng/cdo/plugins/org.polarsys.kitalpha.emde.model.cdo/META-INF/MANIFEST.MF
+++ b/releng/cdo/plugins/org.polarsys.kitalpha.emde.model.cdo/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.kitalpha.emde.model.cdo
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
  org.polarsys.kitalpha.emde.model;visibility:=reexport

--- a/releng/cdo/plugins/pom.xml
+++ b/releng/cdo/plugins/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>

--- a/releng/features/org.polarsys.capella.core.egf.feature/feature.xml
+++ b/releng/features/org.polarsys.capella.core.egf.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.core.egf.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/releng/features/org.polarsys.capella.core.egf.feature/pom.xml
+++ b/releng/features/org.polarsys.capella.core.egf.feature/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.core.egf.feature</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <properties>
     <!-- Skip feature modules in Sonar analysis -->

--- a/releng/features/org.polarsys.capella.headless.feature/feature.xml
+++ b/releng/features/org.polarsys.capella.headless.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.headless.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://www.example.com/description">

--- a/releng/features/org.polarsys.capella.headless.feature/pom.xml
+++ b/releng/features/org.polarsys.capella.headless.feature/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.headless.feature</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <properties>
     <!-- Skip feature modules in Sonar analysis -->

--- a/releng/features/org.polarsys.capella.rcp/feature.xml
+++ b/releng/features/org.polarsys.capella.rcp/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.rcp"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/releng/features/org.polarsys.capella.rcp/pom.xml
+++ b/releng/features/org.polarsys.capella.rcp/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.rcp</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <properties>
     <!-- Skip feature modules in Sonar analysis -->

--- a/releng/plugins/org.polarsys.capella.core.egf/META-INF/MANIFEST.MF
+++ b/releng/plugins/org.polarsys.capella.core.egf/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.polarsys.capella.core.egf;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.core.egf.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/releng/plugins/org.polarsys.capella.core.egf/pom.xml
+++ b/releng/plugins/org.polarsys.capella.core.egf/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.core.egf</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/releng/plugins/org.polarsys.capella.egf.site/category.xml
+++ b/releng/plugins/org.polarsys.capella.egf.site/category.xml
@@ -15,10 +15,10 @@
    <description url="http://www.polarsys.org/capella">
       Capella EGF Patterns
    </description>
-   <feature id="org.polarsys.capella.core.egf.feature" version="7.0.1.qualifier">
+   <feature id="org.polarsys.capella.core.egf.feature" version="7.1.0.qualifier">
       <category name="org.polarsys.capella.egf"/>
    </feature>
-   <feature id="org.polarsys.capella.core.egf.feature.source" version="7.0.1.qualifier">
+   <feature id="org.polarsys.capella.core.egf.feature.source" version="7.1.0.qualifier">
       <category name="org.polarsys.capella.egf"/>
    </feature>
    <category-def name="org.polarsys.capella.egf" label="Capella EGF Patterns"/>

--- a/releng/plugins/org.polarsys.capella.egf.site/pom.xml
+++ b/releng/plugins/org.polarsys.capella.egf.site/pom.xml
@@ -18,13 +18,13 @@
 	<parent>
 		<groupId>org.polarsys</groupId>
 		<artifactId>org.polarsys.capella</artifactId>
-		<version>7.0.1-SNAPSHOT</version>
+		<version>7.1.0-SNAPSHOT</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 
 	<artifactId>org.polarsys.capella.egf.site</artifactId>
 	<packaging>eclipse-repository</packaging>
-	<version>7.0.1-SNAPSHOT</version>
+	<version>7.1.0-SNAPSHOT</version>
 
 	<properties>
     	<sonar.skip>true</sonar.skip>

--- a/releng/plugins/org.polarsys.capella.rcp.product/capella.product
+++ b/releng/plugins/org.polarsys.capella.rcp.product/capella.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Capella" uid="org.polarsys.capella.rcp.product" id="org.polarsys.capella.rcp.product" application="org.polarsys.capella.core.platform.sirius.ui.perspective.id" version="7.0.1.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Capella" uid="org.polarsys.capella.rcp.product" id="org.polarsys.capella.rcp.product" application="org.polarsys.capella.core.platform.sirius.ui.perspective.id" version="7.1.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>

--- a/releng/plugins/org.polarsys.capella.rcp.product/pom.xml
+++ b/releng/plugins/org.polarsys.capella.rcp.product/pom.xml
@@ -17,7 +17,7 @@
 	  <parent>
 	    <groupId>org.polarsys</groupId>
 	    <artifactId>org.polarsys.capella</artifactId>
-	    <version>7.0.1-SNAPSHOT</version>
+	    <version>7.1.0-SNAPSHOT</version>
 	    <relativePath>../../../</relativePath>
 	  </parent>
 	  <properties>
@@ -26,7 +26,7 @@
 
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.rcp.product</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-repository</packaging>
 	<build>
 		<plugins>

--- a/releng/plugins/org.polarsys.capella.rcp.site/category.xml
+++ b/releng/plugins/org.polarsys.capella.rcp.site/category.xml
@@ -15,19 +15,19 @@
    <description url="http://www.polarsys.org/capella">
       Capella
    </description>
-   <feature id="org.polarsys.capella.rcp" version="7.0.1.qualifier">
+   <feature id="org.polarsys.capella.rcp" version="7.1.0.qualifier">
       <category name="org.polarsys.capella.rcp"/>
    </feature>
-   <feature id="org.polarsys.capella.rcp.source" version="7.0.1.qualifier">
+   <feature id="org.polarsys.capella.rcp.source" version="7.1.0.qualifier">
       <category name="org.polarsys.capella.rcp"/>
    </feature>
-   <feature id="org.polarsys.capella.doc.feature" version="7.0.1.qualifier">
+   <feature id="org.polarsys.capella.doc.feature" version="7.1.0.qualifier">
       <category name="org.polarsys.capella.rcp"/>
    </feature>
-   <feature id="org.polarsys.capella.cdo.mock.feature" version="7.0.1.qualifier">
+   <feature id="org.polarsys.capella.cdo.mock.feature" version="7.1.0.qualifier">
       <category name="org.polarsys.capella.rcp"/>
    </feature>
-   <feature id="org.polarsys.capella.viatra.core.feature" version="7.0.1.qualifier">
+   <feature id="org.polarsys.capella.viatra.core.feature" version="7.1.0.qualifier">
       <category name="org.polarsys.capella.rcp"/>
    </feature>
    <feature id="org.polarsys.capella.core.sirius.elk.feature">

--- a/releng/plugins/org.polarsys.capella.rcp.site/pom.xml
+++ b/releng/plugins/org.polarsys.capella.rcp.site/pom.xml
@@ -18,13 +18,13 @@
 	<parent>
 		<groupId>org.polarsys</groupId>
 		<artifactId>org.polarsys.capella</artifactId>
-		<version>7.0.1-SNAPSHOT</version>
+		<version>7.1.0-SNAPSHOT</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 
 	<artifactId>org.polarsys.capella.rcp.site</artifactId>
 	<packaging>eclipse-repository</packaging>
-	<version>7.0.1-SNAPSHOT</version>
+	<version>7.1.0-SNAPSHOT</version>
 	
 	<properties>
     	<sonar.skip>true</sonar.skip>

--- a/releng/plugins/org.polarsys.capella.rcp/META-INF/MANIFEST.MF
+++ b/releng/plugins/org.polarsys.capella.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.rcp;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Require-Bundle: org.polarsys.capella.core.platform.sirius.ui.perspective
 Bundle-Localization: plugin
 Bundle-Vendor: %providerName

--- a/releng/plugins/org.polarsys.capella.rcp/pom.xml
+++ b/releng/plugins/org.polarsys.capella.rcp/pom.xml
@@ -17,7 +17,7 @@
   <parent>
 	<groupId>org.polarsys</groupId>
 	<artifactId>org.polarsys.capella</artifactId>
-	<version>7.0.1-SNAPSHOT</version>
+	<version>7.1.0-SNAPSHOT</version>
 	<relativePath>../../../</relativePath>
   </parent>
   <properties>
@@ -25,6 +25,6 @@
   </properties>
   <groupId>org.polarsys.capella.rcp.feature</groupId>
   <artifactId>org.polarsys.capella.rcp</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/releng/plugins/org.polarsys.capella.targets/pom.xml
+++ b/releng/plugins/org.polarsys.capella.targets/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.polarsys.capella.releng</groupId>
 	<artifactId>capella.target-definition</artifactId>
-	<version>7.0.1-SNAPSHOT</version>
+	<version>7.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<licenses>

--- a/releng/plugins/org.polarsys.capella.test.site/category.xml
+++ b/releng/plugins/org.polarsys.capella.test.site/category.xml
@@ -15,10 +15,10 @@
    <description url="http://www.polarsys.org/capella">
       Capella tests
    </description>
-   <feature id="org.polarsys.capella.test.feature" version="7.0.1.qualifier">
+   <feature id="org.polarsys.capella.test.feature" version="7.1.0.qualifier">
       <category name="org.polarsys.capella.test"/>
    </feature>
-   <feature id="org.polarsys.capella.test.feature.source" version="7.0.1.qualifier">
+   <feature id="org.polarsys.capella.test.feature.source" version="7.1.0.qualifier">
       <category name="org.polarsys.capella.test"/>
    </feature>
    <category-def name="org.polarsys.capella.test" label="Capella Tests"/>

--- a/releng/plugins/org.polarsys.capella.test.site/pom.xml
+++ b/releng/plugins/org.polarsys.capella.test.site/pom.xml
@@ -18,13 +18,13 @@
 	<parent>
 		<groupId>org.polarsys</groupId>
 		<artifactId>org.polarsys.capella</artifactId>
-		<version>7.0.1-SNAPSHOT</version>
+		<version>7.1.0-SNAPSHOT</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 
 	<artifactId>org.polarsys.capella.test.site</artifactId>
 	<packaging>eclipse-repository</packaging>
-	<version>7.0.1-SNAPSHOT</version>
+	<version>7.1.0-SNAPSHOT</version>
 	
 	<properties>
     	<sonar.skip>true</sonar.skip>

--- a/releng/plugins/pom.xml
+++ b/releng/plugins/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>

--- a/samples/In-Flight Entertainment System/In-Flight Entertainment System.capella
+++ b/samples/In-Flight Entertainment System/In-Flight Entertainment System.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.1-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.polarsys</groupId>
 		<artifactId>org.polarsys.capella</artifactId>
-		<version>7.0.1-SNAPSHOT</version>
+		<version>7.1.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	
@@ -29,7 +29,7 @@
 	
 	<groupId>org.polarsys</groupId>
 	<artifactId>org.polarsys.capella.samples</artifactId>
-	<version>7.0.1-SNAPSHOT</version>
+	<version>7.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<build>

--- a/tests/features/org.polarsys.capella.test.feature/feature.xml
+++ b/tests/features/org.polarsys.capella.test.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.polarsys.capella.test.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/tests/features/org.polarsys.capella.test.feature/pom.xml
+++ b/tests/features/org.polarsys.capella.test.feature/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>
   <artifactId>org.polarsys.capella.test.feature</artifactId>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <properties>
     <!-- Skip feature modules in Sonar analysis -->

--- a/tests/plugins/org.polarsys.capella.test.benchmarks.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.benchmarks.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.benchmarks.ju;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.benchmarks.ju.CapellaPerformanceTestsActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.benchmarks.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
+++ b/tests/plugins/org.polarsys.capella.test.benchmarks.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.business.queries.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.business.queries.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.business.queries.ju;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.business.queries.ju.TestBusinessQueriesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysModelLib/sysModelLib.capella
+++ b/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysModelLib/sysModelLib.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/fragments/LA-Logical Functions-RLF-OA2-SysOA2_1.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/fragments/LA-Logical Functions-RLF-OA2-SysOA2_1.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.la:LogicalFunction xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/7.0.0"
     xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/fragments/LA-Logical System-LC2.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/fragments/LA-Logical System-LC2.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.la:LogicalComponent xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/fragments/SA-Capabilities-OC1.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/fragments/SA-Capabilities-OC1.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:Capability xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/fragments/SA-Data.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/fragments/SA-Data.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.information:DataPkg xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/sysmodel.capella
+++ b/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/sysmodel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.commandline.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.polarsys.capella.test.framework,
  org.polarsys.capella.core.validation.commandline,

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/RefreshRemoveExport/RefreshRemoveExport.capella
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/RefreshRemoveExport/RefreshRemoveExport.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/Test Command Line Validation/Test Command Line Validation.capella
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/Test Command Line Validation/Test Command Line Validation.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelLibrary_Sub/sysmodelLibrary_Sub.capella
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelLibrary_Sub/sysmodelLibrary_Sub.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelLibrary_Super/sysmodelLibrary_Super.capella
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelLibrary_Super/sysmodelLibrary_Super.capella
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"/>

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/fragments/EPBSA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/fragments/EPBSA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.epbs:EPBSArchitecture xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/fragments/LA-Logical Functions-RLF-OA2-SysOA2_1.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/fragments/LA-Logical Functions-RLF-OA2-SysOA2_1.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.la:LogicalFunction xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/7.0.0"
     xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/fragments/LA-Logical System-LC2.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/fragments/LA-Logical System-LC2.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.la:LogicalComponent xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/fragments/SA-Capabilities-OC1.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/fragments/SA-Capabilities-OC1.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:Capability xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/fragments/SA-Data.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/fragments/SA-Data.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.information:DataPkg xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/sysmodelProject.capella
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/sysmodelProject.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.common.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.diagram.common.ju/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.polarsys.capella.test.diagram.common.ju;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.diagram.common.ju.TestDiagramCommonPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.diagram.filters.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.diagram.filters.ju.TestDiagramFiltersPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/ElementLabelFilterModel/ElementLabelFilterModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/ElementLabelFilterModel/ElementLabelFilterModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/HideFunctionalExchange/HideFunctionalExchange.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/HideFunctionalExchange/HideFunctionalExchange.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/HideSimplifiedLinksFilter/HideSimplifiedLinksFilter.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/HideSimplifiedLinksFilter/HideSimplifiedLinksFilter.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/InternalLinks/InternalLinks.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/InternalLinks/InternalLinks.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/PB8/PB8.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/PB8/PB8.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/PB9/PB9.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/PB9/PB9.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Project_validation_hideControlNodesFilter/Project_validation_hideControlNodesFilter.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Project_validation_hideControlNodesFilter/Project_validation_hideControlNodesFilter.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Project_validation_hideTechnicalInterfaceFilter/Project_validation_hideTechnicalInterfaceFilter.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Project_validation_hideTechnicalInterfaceFilter/Project_validation_hideTechnicalInterfaceFilter.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/ShowTriggerSourceFunctionFilter/ShowTriggerSourceFunctionFilter.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/ShowTriggerSourceFunctionFilter/ShowTriggerSourceFunctionFilter.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/StandardDiagramFiltersModel/StandardDiagramFiltersModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/StandardDiagramFiltersModel/StandardDiagramFiltersModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Test_delegationWizard/Test_delegationWizard.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Test_delegationWizard/Test_delegationWizard.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/TitleBlocksModel/TitleBlocksModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/TitleBlocksModel/TitleBlocksModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/model2/model2.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/model2/model2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/model3_multpart/model3_multpart.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/model3_multpart/model3_multpart.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.layout.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.diagram.layout.ju/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.polarsys.capella.test.diagram.layout.ju;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.polarsys.capella.test.diagram.layout.ju.layout.provider.LayoutEditPlugin$Implementation
 Require-Bundle: org.eclipse.ui,

--- a/tests/plugins/org.polarsys.capella.test.diagram.layout.ju/model/FC/FC.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.layout.ju/model/FC/FC.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.layout.ju/model/modelCopyLayout/modelCopyLayout.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.layout.ju/model/modelCopyLayout/modelCopyLayout.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.diagram.misc.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.diagram.misc.ju.TestDiagramMiscPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/Bug2579/Bug2579.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/Bug2579/Bug2579.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/DashFunctionBug/DashFunctionBug.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/DashFunctionBug/DashFunctionBug.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/DeleteFromModelWithTarget/DeleteFromModelWithTarget.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/DeleteFromModelWithTarget/DeleteFromModelWithTarget.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/EOLE_AF_UC/EOLE_AF_UC.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/EOLE_AF_UC/EOLE_AF_UC.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/SBOrdering/SBOrdering.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/SBOrdering/SBOrdering.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/StatusLine/StatusLine.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/StatusLine/StatusLine.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/TestCloneDiagram/TestCloneDiagram.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/TestCloneDiagram/TestCloneDiagram.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/allocation-management/allocation-management.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/allocation-management/allocation-management.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1006/bug1006.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1006/bug1006.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1204/bug1204.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1204/bug1204.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1512/bug1512.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1512/bug1512.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1917/bug1917.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1917/bug1917.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug2047/bug2047.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug2047/bug2047.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/component-breakdown/component-breakdown.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/component-breakdown/component-breakdown.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/diagrams-having-parts-as-targets/diagrams-having-parts-as-targets.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/diagrams-having-parts-as-targets/diagrams-having-parts-as-targets.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/insert-remove-components-with-no-parts/insert-remove-simple.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/insert-remove-components-with-no-parts/insert-remove-simple.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testPie/testPie.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testPie/testPie.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testPortSize/testPortSize.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testPortSize/testPortSize.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testRefreshContextualElements/testRefreshContextualElements.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testRefreshContextualElements/testRefreshContextualElements.afm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Mcvh4JdLEe2DZPU2bYNA6g">
   <viewpointReferences xsi:type="metadata:ViewpointReference" id="_MdIjcJdLEe2DZPU2bYNA6g"

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testRefreshContextualElements/testRefreshContextualElements.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testRefreshContextualElements/testRefreshContextualElements.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.diagram.tools.ju;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.diagram.tools.ju.TestDiagramToolsPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/BlackInternalLinks/BlackInternalLinks.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/BlackInternalLinks/BlackInternalLinks.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/CDBCommunication/CDBCommunication.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/CDBCommunication/CDBCommunication.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Component-DragAndDrop/Component-DragAndDrop.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Component-DragAndDrop/Component-DragAndDrop.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/CompositeChains/CompositeChains.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/CompositeChains/CompositeChains.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ContextualInterface/ContextualInterface.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ContextualInterface/ContextualInterface.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramAction/DiagramAction.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramAction/DiagramAction.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramNavigationModel/DiagramNavigationModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramNavigationModel/DiagramNavigationModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramToolsModel/DiagramToolsModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramToolsModel/DiagramToolsModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DndTestModel/DndTestModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DndTestModel/DndTestModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ESProject/ESProject.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ESProject/ESProject.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/EmptyProject/EmptyProject.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/EmptyProject/EmptyProject.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/FCDCollapsingTest/FCDCollapsingTest.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/FCDCollapsingTest/FCDCollapsingTest.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/FunctionalChains/FunctionalChains.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/FunctionalChains/FunctionalChains.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Library1/Library1.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Library1/Library1.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Library2/Library2.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Library2/Library2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/MCBDiagramModel/MCBDiagramModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/MCBDiagramModel/MCBDiagramModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/MSMComputedTransitions/MSMComputedTransitions.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/MSMComputedTransitions/MSMComputedTransitions.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ModelFC/ModelFC.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ModelFC/ModelFC.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/OAB-DragAndDrop.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/OAB-DragAndDrop.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/PABDiagramModel/PABDiagramModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/PABDiagramModel/PABDiagramModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/PhysicalPathDisplay/PhysicalPathDisplay.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/PhysicalPathDisplay/PhysicalPathDisplay.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ReuseOfComponentsModel/ReuseOfComponentsModel/ReuseOfComponentsModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ReuseOfComponentsModel/ReuseOfComponentsModel/ReuseOfComponentsModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SABDiagramModel/SABDiagramModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SABDiagramModel/SABDiagramModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SequenceDiagramProject/SequenceDiagramProject.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SequenceDiagramProject/SequenceDiagramProject.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ShowHideExchangesAndLinks/ShowHideExchangesAndLinks.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ShowHideExchangesAndLinks/ShowHideExchangesAndLinks.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ShowHideFEModel/ShowHideFEModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ShowHideFEModel/ShowHideFEModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SwitchCategory/SwitchCategory.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SwitchCategory/SwitchCategory.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SwitchCategoryHidingInternalEdges/SwitchCategoryHidingInternalEdges.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SwitchCategoryHidingInternalEdges/SwitchCategoryHidingInternalEdges.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/TitleBlocksModel/TitleBlocksModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/TitleBlocksModel/TitleBlocksModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/XABDiagrams/XABDiagrams.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/XABDiagrams/XABDiagrams.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/XDFBToolsTestingModel/XDFBToolsTestingModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/XDFBToolsTestingModel/XDFBToolsTestingModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/opd-fcd-cycle-model/opd-fcd-cycle-model.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/opd-fcd-cycle-model/opd-fcd-cycle-model.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/opd-fcd-exchange-tool-cycle-model/opd-fcd-exchange-tool-cycle-model.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/opd-fcd-exchange-tool-cycle-model/opd-fcd-exchange-tool-cycle-model.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/test/test.capella
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/test/test.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.doc.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.doc.ju/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.polarsys.capella.test.doc.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.doc.ju.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.explorer.activity.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.explorer.activity.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.explorer.activity.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.explorer.activity.ju.TestActivityExplorerPlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.polarsys.capella.test.framework,

--- a/tests/plugins/org.polarsys.capella.test.explorer.activity.ju/model/EmptyModel/EmptyModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.explorer.activity.ju/model/EmptyModel/EmptyModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.fastlinker.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.fastlinker.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.fastlinker.ju; singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.fastlinker.ju.TestFastLinkerPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.fastlinker.ju/model/TestsFastLinker/TestsFastLinker.capella
+++ b/tests/plugins/org.polarsys.capella.test.fastlinker.ju/model/TestsFastLinker/TestsFastLinker.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.fragmentation/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.fragmentation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.fragmentation
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.fragmentation.ju.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/fragments/LA-Logical Functions-RLF-OA2-SysOA2_1.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/fragments/LA-Logical Functions-RLF-OA2-SysOA2_1.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.la:LogicalFunction xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/7.0.0"
     xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/fragments/LA-Logical System-LC2.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/fragments/LA-Logical System-LC2.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.la:LogicalComponent xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/fragments/SA-Capabilities-OC1.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/fragments/SA-Capabilities-OC1.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:Capability xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/fragments/SA-Data.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/fragments/SA-Data.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.information:DataPkg xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/sysmodel.capella
+++ b/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/sysmodel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.framework/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.framework/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.framework;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy
 Require-Bundle: com.google.guava;visibility:=reexport,

--- a/tests/plugins/org.polarsys.capella.test.library.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.library.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.library.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.libraries.ju.TestLibrariesPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary1/MyLibrary1.capella
+++ b/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary1/MyLibrary1.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary2/MyLibrary2.capella
+++ b/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary2/MyLibrary2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary3/MyLibrary3.capella
+++ b/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary3/MyLibrary3.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.library.ju/model/MyProject1/MyProject1.capella
+++ b/tests/plugins/org.polarsys.capella.test.library.ju/model/MyProject1/MyProject1.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.library.ju/model/MyProject2/MyProject2.capella
+++ b/tests/plugins/org.polarsys.capella.test.library.ju/model/MyProject2/MyProject2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.library.ui.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.library.ui.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.library.ui.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.libraries.ui.ju.TestLibrariesUIPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary1/MyLibrary1.capella
+++ b/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary1/MyLibrary1.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary2/MyLibrary2.capella
+++ b/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary2/MyLibrary2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary3/MyLibrary3.capella
+++ b/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary3/MyLibrary3.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyProject1/MyProject1.capella
+++ b/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyProject1/MyProject1.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyProject2/MyProject2.capella
+++ b/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyProject2/MyProject2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.massactions.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.massactions.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.massactions.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.massactions.ju.activator.TestActivator
 Require-Bundle: org.polarsys.capella.test.framework,
  org.polarsys.capella.common.ui.massactions.core,

--- a/tests/plugins/org.polarsys.capella.test.massactions.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
+++ b/tests/plugins/org.polarsys.capella.test.massactions.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.migration.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.migration.ju.TestMigrationPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/ECM_Rapid_ImplementationNonRegression/ECM_Rapid_ImplementationNonRegression.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/ECM_Rapid_ImplementationNonRegression/ECM_Rapid_ImplementationNonRegression.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.1-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/FunctionalChainsNonRegression/FunctionalChainsNonRegression.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/FunctionalChainsNonRegression/FunctionalChainsNonRegression.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.1-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/activate-MSM-filters-6_0_0/activate-MSM-filters-6.1.0.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/activate-MSM-filters-6_0_0/activate-MSM-filters-6.1.0.capella
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.1-->
+<!--Capella_Version_7.1.0-->
 <xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"/>

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/activate-filters-6_0_0/activate-filters-6_0_0.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/activate-filters-6_0_0/activate-filters-6_0_0.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.1-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2agg-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2agg-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVb2a-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVb2a-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVboth_a2b_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVboth_a2b_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVboth_b2a_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVboth_b2a_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVnone_a2b_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVnone_a2b_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVnone_b2a_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2ass-NAVnone_b2a_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2com-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2com-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2uns-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/agg2uns-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVb2a-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVb2a-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVboth_a2b_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVboth_a2b_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVboth_b2a_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVboth_b2a_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVnone_a2b_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVnone_a2b_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVnone_b2a_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2agg-NAVnone_b2a_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVa2b-ABSa2b/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVa2b-ABSa2b/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVa2b-ABSb2a/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVa2b-ABSb2a/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVa2b-ABSboth/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVa2b-ABSboth/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVb2a-ABSa2b/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVb2a-ABSa2b/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVb2a-ABSb2a/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVb2a-ABSb2a/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVb2a-ABSboth/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVb2a-ABSboth/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVb2a-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVb2a-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_a2b_first-ABSa2b/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_a2b_first-ABSa2b/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_a2b_first-ABSb2a/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_a2b_first-ABSb2a/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_a2b_first-ABSboth/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_a2b_first-ABSboth/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_a2b_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_a2b_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_b2a_first-ABSa2b/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_b2a_first-ABSa2b/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_b2a_first-ABSb2a/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_b2a_first-ABSb2a/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_b2a_first-ABSboth/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_b2a_first-ABSboth/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_b2a_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVboth_b2a_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_a2b_first-ABSa2b/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_a2b_first-ABSa2b/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_a2b_first-ABSb2a/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_a2b_first-ABSb2a/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_a2b_first-ABSboth/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_a2b_first-ABSboth/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_a2b_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_a2b_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_b2a_first-ABSa2b/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_b2a_first-ABSa2b/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_b2a_first-ABSb2a/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_b2a_first-ABSb2a/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_b2a_first-ABSboth/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_b2a_first-ABSboth/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_b2a_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2ass-NAVnone_b2a_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVb2a-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVb2a-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVboth_a2b_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVboth_a2b_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVboth_b2a_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVboth_b2a_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVnone_a2b_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVnone_a2b_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVnone_b2a_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2com-NAVnone_b2a_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2uns-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/ass2uns-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2agg-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2agg-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVb2a-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVb2a-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVboth_a2b_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVboth_a2b_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVboth_b2a_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVboth_b2a_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVnone_a2b_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVnone_a2b_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVnone_b2a_first-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2ass-NAVnone_b2a_first-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2com-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2com-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2uns-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/com2uns-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/uns2agg-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/uns2agg-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/uns2ass-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/uns2ass-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/uns2com-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/uns2com-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/uns2uns-NAVa2b-ABSnone/RelationStabilityCDB.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/doremi-4873-datatest/uns2uns-NAVa2b-ABSnone/RelationStabilityCDB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/fragments/LA-Logical Functions-RLF-OA2-SysOA2_1.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/fragments/LA-Logical Functions-RLF-OA2-SysOA2_1.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.1-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.la:LogicalFunction xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/7.0.0"
     xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/fragments/LA-Logical System-LC2.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/fragments/LA-Logical System-LC2.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.1-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.la:LogicalComponent xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/fragments/SA-Capabilities-OC1.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/fragments/SA-Capabilities-OC1.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.1-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:Capability xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/fragments/SA-Data.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/fragments/SA-Data.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.1-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.information:DataPkg xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/migration.sysmodel.capella
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/migration.sysmodel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.1-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.model.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.model.ju.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/CopyPasteTestCase_Lib/CopyPasteTestCase_Lib.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/CopyPasteTestCase_Lib/CopyPasteTestCase_Lib.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/CopyPasteTestCase_Project/CopyPasteTestCase_Project.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/CopyPasteTestCase_Project/CopyPasteTestCase_Project.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/DiagramLabelModel/DiagramLabelModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/DiagramLabelModel/DiagramLabelModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourcePrj/DiffMergeSourcePrj.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourcePrj/DiffMergeSourcePrj.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourceT4CPrj/DiffMergeSourcePrj.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourceT4CPrj/DiffMergeSourcePrj.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourceV1Prj/DiffMergeSourcePrj.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourceV1Prj/DiffMergeSourcePrj.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeTargetPrj/DiffMergeTargetPrj.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeTargetPrj/DiffMergeTargetPrj.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/ISMessage/ISMessage.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/ISMessage/ISMessage.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/ObfuscateModelTestCase/ObfuscateModelTestCase.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/ObfuscateModelTestCase/ObfuscateModelTestCase.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/RenameModel/RenameModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/RenameModel/RenameModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/SemanticDnd/SemanticDnd.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/SemanticDnd/SemanticDnd.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/[rename model]/[rename model].capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/[rename model]/[rename model].capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/[rename model]/fragments/[OA].capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/[rename model]/fragments/[OA].capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.oa:OperationalAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/capabilityExt/capabilityExt.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/capabilityExt/capabilityExt.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/copyPasteLayout/copyPasteLayout.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/copyPasteLayout/copyPasteLayout.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/detach_lib/version_ok/p1.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/detach_lib/version_ok/p1.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-library/fragments/SA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-library/fragments/SA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:SystemAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-library/gch-library.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-library/gch-library.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-project/fragments/SA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-project/fragments/SA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:SystemAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-project/gch-project.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-project/gch-project.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/L1/L1.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/L1/L1.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/L2/L2.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/L2/L2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/LIB/LIB.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/LIB/LIB.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/P/P.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/P/P.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/PROJECT/PROJECT.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/PROJECT/PROJECT.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/lcdecomposition/lcdecomposition.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/lcdecomposition/lcdecomposition.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/miscmodel/miscmodel.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/miscmodel/miscmodel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/renameTest 1  2/renameTest 1  2.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/renameTest 1  2/renameTest 1  2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/sortcontent/sortcontent.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/sortcontent/sortcontent.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/test_B/test_B.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/test_B/test_B.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/test_C/test_C.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/test_C/test_C.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.navigator.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.navigator.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.navigator.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.navigator.ju.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.navigator.ju/model/Component-Part-ComponentPkg-DragAndDrop/Component-Part-ComponentPkg-DragAndDrop.capella
+++ b/tests/plugins/org.polarsys.capella.test.navigator.ju/model/Component-Part-ComponentPkg-DragAndDrop/Component-Part-ComponentPkg-DragAndDrop.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.navigator.ju/model/NavigableElements/NavigableElements.capella
+++ b/tests/plugins/org.polarsys.capella.test.navigator.ju/model/NavigableElements/NavigableElements.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.navigator.ju/model/NavigatorEmptyProject/NavigatorEmptyProject.capella
+++ b/tests/plugins/org.polarsys.capella.test.navigator.ju/model/NavigatorEmptyProject/NavigatorEmptyProject.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.navigator.ju/model/emptyDiagram/emptyDiagram.capella
+++ b/tests/plugins/org.polarsys.capella.test.navigator.ju/model/emptyDiagram/emptyDiagram.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.odesign/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.odesign/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.odesign
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.odesign.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.polarsys.capella.test.framework,

--- a/tests/plugins/org.polarsys.capella.test.platform.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.platform.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.platform.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.platform.ju.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/TestNavigationDoubleClick.capella
+++ b/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/TestNavigationDoubleClick.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.progressmonitoring.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.progressmonitoring.ju.internal.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.polarsys.capella.test.framework,

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/model/setProgress/setProgress.capella
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/model/setProgress/setProgress.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellamodeller="http://www.polarsys.org/capella/core/modeller/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.projection.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.projection.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.projection.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.projection.ju.ProjectionTestActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.projection.ju/model/FunctionalChain/FunctionalChain.capella
+++ b/tests/plugins/org.polarsys.capella.test.projection.ju/model/FunctionalChain/FunctionalChain.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.projection.ju/model/testInterfacesFromAllocatedFunctions/testInterfacesFromAllocatedFunctions.capella
+++ b/tests/plugins/org.polarsys.capella.test.projection.ju/model/testInterfacesFromAllocatedFunctions/testInterfacesFromAllocatedFunctions.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/MassActions/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/MassActions/model/In-Flight Entertainment System/In-Flight Entertainment System.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/contexts/default/a.ctx
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/contexts/default/a.ctx
@@ -1,0 +1,21 @@
+--- RCPTT testcase ---
+Format-Version: 1.0
+Context-Type: org.eclipse.rcptt.ctx.preferences
+Element-Name: a
+Element-Type: context
+Element-Version: 2.0
+Id: _BkFAYPsnEe6ro_n9Hx5ebw
+Runtime-Version: 2.5.5.202312181455
+Save-Time: 4/15/24, 2:52 PM
+
+------=_.q7.content-3d2e0690-ce48-3609-83e0-c704d49f1eaf
+Content-Type: q7/binary
+Entry-Name: .q7.content
+
+UEsDBBQACAgIAAAAIQAAAAAAAAAAAAAAAAAIAAkALmNvbnRlbnRVVAUAAQAAAACFj8FqwkAQQO8F/2GZ
+u7tWsLTBVaoo7UHIsZ4krmO6NJkNu2Ozn++mkJhbb8Pw5j1muY51JX7RB+tIw7OcgUAy7mKp1HDj6/QV
+1qvJ09L5UqKpbBNQetMwS8NRNh6v6NMBhix/zFtHjJFFrG02uOedO9UoZGmv4Zu5yZRq21a6upQpoL4O
+nz3yb28Q9FQn+CNVItWIBEFFjRoKEPai4bT52b8f80A7fPHuRG8fcYHnFoSpsKB8XGB/Q1Dp/TtQSwcI
+eWN7770AAAAnAQAAUEsBAhQAFAAICAgAAAAhAHlje++9AAAAJwEAAAgACQAAAAAAAAAAAAAAAAAAAC5j
+b250ZW50VVQFAAEAAAAAUEsFBgAAAAABAAEAPwAAAPwAAAAAAA==
+------=_.q7.content-3d2e0690-ce48-3609-83e0-c704d49f1eaf--

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/Bug2242/Bug2242.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/Bug2242/Bug2242.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/Bug2242/fragments/LA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/Bug2242/fragments/LA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.la:LogicalArchitecture xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/Bug2242/fragments/OA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/Bug2242/fragments/OA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.oa:OperationalAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/Bug2242/fragments/SA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/Bug2242/fragments/SA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:SystemAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/ConstraintEdition/ConstraintEdition.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/ConstraintEdition/ConstraintEdition.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/CopyPasteNoDuplicate/CopyPasteNoDuplicate.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/CopyPasteNoDuplicate/CopyPasteNoDuplicate.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DeleteLifeline/DeleteLifeline.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DeleteLifeline/DeleteLifeline.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiagramNavigationModel/OnDoubleClick/DiagramNavigationModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiagramNavigationModel/OnDoubleClick/DiagramNavigationModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_1/TestModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_1/TestModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_1/fragments/OA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_1/fragments/OA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.oa:OperationalAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_1/fragments/SA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_1/fragments/SA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:SystemAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_2/TestModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_2/TestModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_2/fragments/OA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_2/fragments/OA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.oa:OperationalAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_2/fragments/SA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_2/fragments/SA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:SystemAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_TestModel_Import_1/TestModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_TestModel_Import_1/TestModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_TestModel_Import_2/TestModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_TestModel_Import_2/TestModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/EOLE_AF/EOLE_AF.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/EOLE_AF/EOLE_AF.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/IFEWithPropertyValue/In-Flight Entertainment System/In-Flight Entertainment System.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/IFEWithPropertyValue/In-Flight Entertainment System/In-Flight Entertainment System.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/In-Flight Entertainment System/In-Flight Entertainment System.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/In-Flight Entertainment System/In-Flight Entertainment System.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/InterfaceDelegation/InterfaceDelegation.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/InterfaceDelegation/InterfaceDelegation.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/MelodyProject1/MelodyProject1.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/MelodyProject1/MelodyProject1.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/MultipleFunctions/MultipleFunctions.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/MultipleFunctions/MultipleFunctions.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/RefreshAllSubRepresentation_Empty/RefreshAllSubRepresentation_Empty.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/RefreshAllSubRepresentation_Empty/RefreshAllSubRepresentation_Empty.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/RefreshAllSubRepresentations/model.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/RefreshAllSubRepresentations/model.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/SearchWithOptions/SearchWithOptions.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/SearchWithOptions/SearchWithOptions.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-library/frag-library.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-library/frag-library.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/frag-model.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/frag-model.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/fragments/LA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/fragments/LA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.la:LogicalArchitecture xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/fragments/OA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/fragments/OA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.oa:OperationalAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/fragments/PA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/fragments/PA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.pa:PhysicalArchitecture xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/fragments/SA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/fragments/SA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:SystemAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/fragmentedModel/fragmentedModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/fragmentedModel/fragmentedModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/fragmentedModel/fragments/SA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/fragmentedModel/fragments/SA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:SystemAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/previous_version/previous_version.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/previous_version/previous_version.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/renameTest 1  2/renameTest 1  2.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/renameTest 1  2/renameTest 1  2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/renameTest/renameTest.capella
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/renameTest/renameTest.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.rcptt/pom.xml
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.polarsys</groupId>
 		<artifactId>org.polarsys.capella.tests.plugins</artifactId>
-		<version>7.0.1-SNAPSHOT</version>
+		<version>7.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.polarsys</groupId>
 	<artifactId>org.polarsys.capella.test.rcptt</artifactId>

--- a/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.re.updateconnections.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.re.updateconnections.ju.UpdateConnectionsTestsActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest1/updatelinksTest1.capella
+++ b/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest1/updatelinksTest1.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest2/updatelinksTest2.capella
+++ b/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest2/updatelinksTest2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest2Lib/updatelinksTest2Lib.capella
+++ b/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest2Lib/updatelinksTest2Lib.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest3Multipart/updatelinksTest3Multipart.capella
+++ b/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest3Multipart/updatelinksTest3Multipart.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.recrpl.ju;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.recrpl.ju.RecRplTestPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/compliance/compliance.capella
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/compliance/compliance.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/dependencies/dependencies.capella
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/dependencies/dependencies.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-library/frag-library.capella
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-library/frag-library.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/frag-model.capella
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/frag-model.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/fragments/LA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/fragments/LA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.la:LogicalArchitecture xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/fragments/OA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/fragments/OA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.oa:OperationalAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/fragments/PA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/fragments/PA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.pa:PhysicalArchitecture xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"
     xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/fragments/SA.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/fragments/SA.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:SystemAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/lib-fecepl/lib-fecepl.capella
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/lib-fecepl/lib-fecepl.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/locationPart/locationPart.capella
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/locationPart/locationPart.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/re-cepl/re-cepl.capella
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/re-cepl/re-cepl.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/re/re.capella
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/re/re.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/recs/recs.capella
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/recs/recs.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/whole-content-actor/whole-content-actor.capella
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/whole-content-actor/whole-content-actor.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.richtext.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.richtext.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.richtext.ju;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.richtext.ju.RichtextTestPlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.polarsys.capella.test.framework,

--- a/tests/plugins/org.polarsys.capella.test.richtext.ju/model/RichtextTestModel/RichtextTestModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.richtext.ju/model/RichtextTestModel/RichtextTestModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.run/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.run/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.run;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Automatic-Module-Name: org.polarsys.capella.test.run
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.jdt.core,

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.semantic.queries.ju;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.semantic.queries.ju.TestSemanticQueriesPlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.polarsys.capella.test.framework,

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/model/SemanticQueries/SemanticQueries.capella
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/model/SemanticQueries/SemanticQueries.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.semantic.ui.ju;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.semantic.ui.ju.TestSemanticBrowserUIPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.polarsys.capella.core.data.gen,
  org.polarsys.capella.core.ui.semantic.browser.sirius,
  org.polarsys.capella.core.ui.toolkit,
- org.polarsys.capella.core.ui.properties;bundle-version="7.0.1"
+ org.polarsys.capella.core.ui.properties;bundle-version="7.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.polarsys.capella.test.semantic.ui.ju,
  org.polarsys.capella.test.semantic.ui.ju.testsuites

--- a/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/model/DiagramNavigationModel/DiagramNavigationModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/model/DiagramNavigationModel/DiagramNavigationModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/model/SemanticBrowserNavigation/SemanticBrowserNavigation.afm
+++ b/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/model/SemanticBrowserNavigation/SemanticBrowserNavigation.afm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_F1_B4CzzEe2kpJxa-hdswA">
   <viewpointReferences xsi:type="metadata:ViewpointReference" id="_F2jpoCzzEe2kpJxa-hdswA"

--- a/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/model/SemanticBrowserNavigation/SemanticBrowserNavigation.capella
+++ b/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/model/SemanticBrowserNavigation/SemanticBrowserNavigation.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.suite.inui.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.suite.inui.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.suite.inui.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %providerName

--- a/tests/plugins/org.polarsys.capella.test.suite.local.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.suite.local.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.suite.local.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %providerName

--- a/tests/plugins/org.polarsys.capella.test.suite.notinui.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.suite.notinui.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.suite.notinui.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %providerName

--- a/tests/plugins/org.polarsys.capella.test.suites.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.suites.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.suites.ju
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %providerName

--- a/tests/plugins/org.polarsys.capella.test.table/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.table/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.table;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Automatic-Module-Name: org.polarsys.capella.test.table
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.eclipse.ui.plugin,

--- a/tests/plugins/org.polarsys.capella.test.table/model/CrossTable-OA/.project
+++ b/tests/plugins/org.polarsys.capella.test.table/model/CrossTable-OA/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>tableRequirements</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
+	</natures>
+</projectDescription>

--- a/tests/plugins/org.polarsys.capella.test.table/model/InterfaceTable/InterfaceTable.capella
+++ b/tests/plugins/org.polarsys.capella.test.table/model/InterfaceTable/InterfaceTable.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.table/model/SF-OA/SF-OA.capella
+++ b/tests/plugins/org.polarsys.capella.test.table/model/SF-OA/SF-OA.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.transition.ju;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.transition.ju.TransitionTestPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/ActorTransition_01/ActorTransition_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/ActorTransition_01/ActorTransition_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/AllProjectionModels/AllProjectionModels.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/AllProjectionModels/AllProjectionModels.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/AlreadyTransitionedActor/AlreadyTransitionedActor.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/AlreadyTransitionedActor/AlreadyTransitionedActor.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_CEPL/Context_CEPL.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_CEPL/Context_CEPL.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_I01/Context_I01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_I01/Context_I01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_SF01/Context_SF01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_SF01/Context_SF01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_IU01_01/CreateRule_IU01_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_IU01_01/CreateRule_IU01_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_RA01_01/CreateRule_RA01_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_RA01_01/CreateRule_RA01_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_Scenario/CreateRule_Scenario.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_Scenario/CreateRule_Scenario.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/ES2ES_MoveFunction/ES2ES_MoveFunction.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/ES2ES_MoveFunction/ES2ES_MoveFunction.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/ES2ES_MoveFunctionPort/ES2ES_MoveFunctionPort.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/ES2ES_MoveFunctionPort/ES2ES_MoveFunctionPort.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/EmptySkeletonProject/EmptySkeletonProject.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/EmptySkeletonProject/EmptySkeletonProject.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_CFE01_01/Exception_CFE01_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_CFE01_01/Exception_CFE01_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_01/Exception_FCI01_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_01/Exception_FCI01_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_02/Exception_FCI01_02.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_02/Exception_FCI01_02.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_03/Exception_FCI01_03.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_03/Exception_FCI01_03.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FE01_01/Exception_FE01_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FE01_01/Exception_FE01_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_IP01_01/Exception_IP01_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_IP01_01/Exception_IP01_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_ME01G_01/Exception_ME01G_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_ME01G_01/Exception_ME01G_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_OAI01_01/Exception_OAI01_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_OAI01_01/Exception_OAI01_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/FunctionalChain/FunctionalChain.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/FunctionalChain/FunctionalChain.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Generation_Interface/Generation_Interface.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Generation_Interface/Generation_Interface.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/LCPCTransition_01/LCPCTransition_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/LCPCTransition_01/LCPCTransition_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/LCPCTransition_02/LCPCTransition_02.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/LCPCTransition_02/LCPCTransition_02.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/LaInnerLC/LaInnerLC.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/LaInnerLC/LaInnerLC.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Library/Library.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Library/Library.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/NonLeafAllocation/NonLeafAllocation.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/NonLeafAllocation/NonLeafAllocation.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/PLCE/PLCE.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/PLCE/PLCE.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/PartParent/PartParent.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/PartParent/PartParent.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/StateEventTransition/StateEventTransition.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/StateEventTransition/StateEventTransition.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/SystemTransition/SystemTransition.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/SystemTransition/SystemTransition.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Transition/Transition.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Transition/Transition.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/TwiceAllocation/TwiceAllocation.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/TwiceAllocation/TwiceAllocation.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_FC01_01/UpdateRule_FC01_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_FC01_01/UpdateRule_FC01_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_MEG01EI_01/UpdateRule_MEG01EI_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_MEG01EI_01/UpdateRule_MEG01EI_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_NE01_01/UpdateRule_NE01_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_NE01_01/UpdateRule_NE01_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_ST01_01/UpdateRule_ST01_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_ST01_01/UpdateRule_ST01_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/enumInPropertyPkgUnderSysEng/enumInPropertyPkgUnderSysEng.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/enumInPropertyPkgUnderSysEng/enumInPropertyPkgUnderSysEng.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/fc2fs/fc2fs.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/fc2fs/fc2fs.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/lc-to-pc-nature-transition/transition.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/lc-to-pc-nature-transition/transition.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/pv/pv.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/pv/pv.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/reconciliation.communicationlinks/reconciliation.communicationlinks.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/reconciliation.communicationlinks/reconciliation.communicationlinks.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/reconciliation.interfacelinks/reconciliation.interfacelinks.capella
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/reconciliation.interfacelinks/reconciliation.interfacelinks.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.polarsys.capella.test.validation.rules.ju;singleton:=true
-Bundle-Version: 7.0.1.qualifier
+Bundle-Version: 7.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.validation.rules.ju.TestValidationRulesPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Bug2438/Bug2438.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Bug2438/Bug2438.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/DCON_01/DCON_01.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/DCON_01/DCON_01.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/I_34_Test_OK/I_34_Test_OK.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/I_34_Test_OK/I_34_Test_OK.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/I_34_Test_OK/fragments/SA-Capabilities-Capability_Fragmented.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/I_34_Test_OK/fragments/SA-Capabilities-Capability_Fragmented.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.ctx:Capability xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/7.0.0"
     id="c4f350d3-4e63-4599-ac6d-56f293c55e99"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Library_validation12/Library_validation12.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Library_validation12/Library_validation12.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Library xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/NoStackOverflowModel/NoStackOverflowModel.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/NoStackOverflowModel/NoStackOverflowModel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycle6/PackageCycle6.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycle6/PackageCycle6.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest1/PackageCycleTest1.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest1/PackageCycleTest1.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest2/PackageCycleTest2.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest2/PackageCycleTest2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest3/PackageCycleTest3.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest3/PackageCycleTest3.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest4/PackageCycleTest4.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest4/PackageCycleTest4.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest5/PackageCycleTest5.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest5/PackageCycleTest5.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation10/Project_validation10.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation10/Project_validation10.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation11/Project_validation11.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation11/Project_validation11.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation12/Project_validation12.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation12/Project_validation12.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation2/Project_validation2.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation2/Project_validation2.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation3/Project_validation3.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation3/Project_validation3.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation4/Project_validation4.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation4/Project_validation4.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation5/Project_validation5.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation5/Project_validation5.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation7/Project_validation7.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation7/Project_validation7.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation8/Project_validation8.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation8/Project_validation8.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation9/Project_validation9.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation9/Project_validation9.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation_12/Project_validation_12.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation_12/Project_validation_12.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnDesignTest/RulesOnDesignTest.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnDesignTest/RulesOnDesignTest.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnIntegrityTest/RulesOnIntegrityTest.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnIntegrityTest/RulesOnIntegrityTest.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnIntegrityTest/fragments/OA-Operational Activities-Root Operational Activity-OperationalActivity 1.capellafragment
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnIntegrityTest/fragments/OA-Operational Activities-Root Operational Activity-OperationalActivity 1.capellafragment
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.oa:OperationalActivity xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/7.0.0"
     id="a0c7858c-8d15-438b-9007-c7b04adfdb9f"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnQualityTest/RulesOnQualityTest.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnQualityTest/RulesOnQualityTest.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnTransitionTest/RulesOnTransitionTest.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnTransitionTest/RulesOnTransitionTest.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/exchange-item-instance-and-part-model.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/exchange-item-instance-and-part-model.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/instance-role-same-name-as-represented-instance/instance-role-same-name-as-represented-instance.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/instance-role-same-name-as-represented-instance/instance-role-same-name-as-represented-instance.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testFunctionalExchangeNameConsistency/testFunctionalExchangeNameConsistency.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testFunctionalExchangeNameConsistency/testFunctionalExchangeNameConsistency.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testOnRules/testOnRules.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testOnRules/testOnRules.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testUnsynchronizedExchangeItems/testUnsynchronizedExchangeItems.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testUnsynchronizedExchangeItems/testUnsynchronizedExchangeItems.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testUnusedExchangeItems/testUnusedExchangeItems.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testUnusedExchangeItems/testUnusedExchangeItems.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/validation.mergerTest/validation.mergerTest.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/validation.mergerTest/validation.mergerTest.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_7.0.0-->
+<!--Capella_Version_7.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/7.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/7.0.0"

--- a/tests/plugins/pom.xml
+++ b/tests/plugins/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.polarsys</groupId>
     <artifactId>org.polarsys.capella</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.polarsys</groupId>


### PR DESCRIPTION
- Bump commits can be merged after review and ci checks
- capella.vp modification, .afm expected version and modification of tests data might still needs discussion
- for the moment only Capella is bumped, Kitalpha will be bumped if needed.