### PR TITLE
[releng] Update orbit location from milestone to release 4.40

### DIFF
--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -58,7 +58,7 @@ location egit "https://archive.eclipse.org/egit/updates-6.6.1" {
 	org.eclipse.egit.source.feature.group
 }
 
-location orbit "https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202604101740" {
+location orbit "https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.40.0" {
 	slf4j.api
 	ch.qos.logback.classic
 	ch.qos.logback.core


### PR DESCRIPTION
Update the orbit location in capella.target-definition.targetplatform from https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202604101740 (deleted milestone) to
https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.40.0