### PR TITLE
#2992 Enrich common command line option to handle more import/exports cases

### DIFF
--- a/core/plugins/org.polarsys.capella.core.commandline.core/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.commandline.core/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.polarsys.capella.common.tools.report;visibility:=reexport,
  org.polarsys.capella.core.model.handler,
  org.polarsys.capella.core.application,
  org.polarsys.capella.core.af.integration,
- org.polarsys.capella.commandline.doc
+ org.polarsys.capella.commandline.doc,
+ org.apache.commons.commons-io
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.polarsys.capella.core.commandline.core

--- a/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/AbstractCommandLine.java
+++ b/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/AbstractCommandLine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2026 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,8 @@
 package org.polarsys.capella.core.commandline.core;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -107,7 +109,7 @@ public class AbstractCommandLine implements ICommandLine {
       logErrorAndThrowException(Messages.outputfolder_mandatory);
     }
     // check -import argument
-    if (isEmtyOrNull(argHelper.getImportProjects())) {
+    if (isEmtyOrNull(argHelper.getImportProjects()) && isEmtyOrNull(argHelper.getImportAllProjects())) {
       setMode(CommandLineMode.NO_IMPORT);
       // project are not imported => check that -filepath and -outputfolder exists into the workspace
       checkFilePath();
@@ -135,9 +137,18 @@ public class AbstractCommandLine implements ICommandLine {
     }
 
     else if (CommandLineMode.IMPORT.equals(mode)) {
+      String projectsToImport = argHelper.getImportProjects();
+      String allProjectsToImport = argHelper.getImportAllProjects();
       try {
-        importProjects(toList(argHelper.getImportProjects()));
-      } catch (CoreException exception) {
+        List<String> projectList = new ArrayList<>();
+        if (projectsToImport != null) {
+          projectList.addAll(toList(projectsToImport));
+        }
+        if (allProjectsToImport != null) {
+          projectList.addAll(getAllProjectsInFolder(allProjectsToImport));
+        }
+        importProjects(projectList);
+      } catch (CoreException | IOException exception) {
         throw new CommandLineException(exception.getMessage());
       }
     }
@@ -365,10 +376,10 @@ public class AbstractCommandLine implements ICommandLine {
   }
 
   /**
-   * Transform a space separated list of strings into a List
+   * Transforms a space separated list of strings into a List
    *
-   * @param string
-   * @return
+   * @param string text to split
+   * @return list of values
    */
   protected List<String> toList(String string) {
     List<String> list = new ArrayList<String>();
@@ -376,6 +387,21 @@ public class AbstractCommandLine implements ICommandLine {
       list.add(path.trim());
     }
     return list;
+  }
+
+  protected List<String> getAllProjectsInFolder(String folder) throws IOException {
+    java.nio.file.Path rootFolderPath = Paths.get(folder);
+
+    List<String> allProjects = Files.list(rootFolderPath).filter(path -> {
+      boolean isProjectDirectory = Files.isDirectory(path) && Files.exists(path.resolve(".project"));
+      boolean isProjectZip = path.toString().endsWith(".zip");
+      return isProjectDirectory || isProjectZip;
+    }).map(java.nio.file.Path::toString)
+        .toList();
+    if (allProjects.isEmpty()) {
+      throw new IOException(String.format("The folder '%s' does not contain any project.", folder));
+    }
+    return allProjects;
   }
 
   /**

--- a/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/CommandLineArgumentHelper.java
+++ b/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/CommandLineArgumentHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2026 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,14 +24,22 @@ public class CommandLineArgumentHelper {
 
   private String input;
   private String outputFolder;
+  
   private boolean helpNeeded;
   private String logFilePath;
   private String appid;
   private String importProjects;
+  private String importAllProjects;
   private String exportZips;
   private boolean forceImport;
   private boolean copyOnWorkspace = false;
   private boolean backup;
+
+  private String exportProjects;
+  private boolean singleZip;
+  private boolean exportCopy;
+  private String exportTarget;
+
   /**
    * @deprecated (use -input instead)
    */
@@ -53,6 +61,7 @@ public class CommandLineArgumentHelper {
   @Deprecated
   private String zipNameProject;
 
+
   protected static String[] args;
 
   public static CommandLineArgumentHelper getInstance() {
@@ -68,7 +77,8 @@ public class CommandLineArgumentHelper {
   }
 
   public void parseArgs(String[] args) {
-    ArgumentsHelper helper = ArgumentsHelper.getInstance();
+    // Avoid singleton to be able to chain commands.
+    ArgumentsHelper helper = new ArgumentsHelper();
     helper.loadArguments(args);
     
     helpNeeded = helper.hasParameter(CommandLineConstants.HELP);
@@ -76,6 +86,7 @@ public class CommandLineArgumentHelper {
     copyOnWorkspace = helper.hasParameter(CommandLineConstants.COPY_ON_WORKSPACE);
     appid = helper.getString(CommandLineConstants.ID);
     importProjects = helper.getString(CommandLineConstants.IMPORT);
+    importAllProjects = helper.getString(CommandLineConstants.IMPORT_ALL);
     exportZips = helper.getString(CommandLineConstants.EXPORTZIP);
     forceImport = helper.hasParameter(CommandLineConstants.FORCEIMPORT);
     exportProject = helper.getString(CommandLineConstants.EXPORT);
@@ -85,6 +96,11 @@ public class CommandLineArgumentHelper {
     outputFolder = helper.getString(CommandLineConstants.OUTPUTFOLDER);
     logFilePath = helper.getString(CommonArgumentsConstants.LOG_FILE_PATH);
     backup = helper.hasParameter(CommandLineConstants.BACKUP);
+    
+    singleZip = helper.hasParameter(CommandLineConstants.SINGLE_ZIP);
+    exportProjects = helper.getString(CommandLineConstants.EXPORT_LIST);
+    exportCopy = helper.hasParameter(CommandLineConstants.EXPORT_COPY);
+    exportTarget = helper.getString(CommandLineConstants.EXPORT_TARGET);
   }
 
   /**
@@ -128,6 +144,13 @@ public class CommandLineArgumentHelper {
    */
   public String getImportProjects() {
     return importProjects;
+  }
+
+  /**
+   * @return the importAllProjects
+   */
+  public String getImportAllProjects() {
+    return importAllProjects;
   }
 
   /**
@@ -196,4 +219,42 @@ public class CommandLineArgumentHelper {
   public boolean isBackupNeeded() {
     return backup;
   }
+  
+  /**
+   * Returns true if the export must create a single archive.
+   * 
+   * @return path of a file
+   */
+  public boolean isSingleZip() {
+    return singleZip;
+  }
+  
+  /**
+   * Returns the path of the folder to zip projects in.
+   * 
+   * @return path of a file
+   */
+  public String getExportTarget() {
+    return exportTarget;
+  }
+
+  /**
+   * Returns true if the export must only perform a copy.
+   * 
+   * @return true for copy
+   */
+  public boolean isExportCopy() {
+    return exportCopy;
+  }
+
+  /**
+   * Returns the list of project to export.
+   * 
+   * @return path of a file
+   */
+  public String getExportProjects() {
+    return exportProjects;
+  }
+
+
 }

--- a/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/CommandLineConstants.java
+++ b/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/CommandLineConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2026 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,13 +15,18 @@ package org.polarsys.capella.core.commandline.core;
 import org.polarsys.capella.common.application.CommonArgumentsConstants;
 
 /**
+ * Constants for command line options.
  */
 public class CommandLineConstants {
+
+  public static final String LIST_SEPARATOR = "|"; //$NON-NLS-1$
+  public static final String ALL_ARGUMENT = "/all"; //$NON-NLS-1$
 
   public static final String HELP = "-help";//$NON-NLS-1$
   public static final String ID = "-appid"; //$NON-NLS-1$
   public static final String DATA = "-data";//$NON-NLS-1$
   public static final String IMPORT = "-import"; //$NON-NLS-1$
+  public static final String IMPORT_ALL = "-importAll"; //$NON-NLS-1$
   public static final String FORCEIMPORT = "-forceimport"; //$NON-NLS-1$
   public static final String EXPORTZIP = "-exportZip"; //$NON-NLS-1$
   @Deprecated
@@ -37,5 +42,11 @@ public class CommandLineConstants {
   public static final String FORCEOUTPUTFOLDERCREATION = "-forceoutputfoldercreation"; //$NON-NLS-1$
   public static final String LOG_FILE_PATH = CommonArgumentsConstants.LOG_FILE_PATH;
   public static final String BACKUP = "-backup"; //$NON-NLS-1$
+
+  public static final String EXPORT_LIST = "-exportProjects"; //$NON-NLS-1$  
+  public static final String SINGLE_ZIP = "-singleZip"; //$NON-NLS-1$
+  public static final String EXPORT_COPY = "-exportCopy"; //$NON-NLS-1$
+  
+  public static final String EXPORT_TARGET = "-exportTarget"; //$NON-NLS-1$
 
 }

--- a/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/DefaultCommandLine.java
+++ b/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/DefaultCommandLine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2020, 2026 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,12 +17,12 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -36,10 +36,12 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.apache.commons.io.FileUtils;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
@@ -58,7 +60,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 public class DefaultCommandLine extends AbstractCommandLine {
-  public static String ALL_ARGUMENT = "/all"; //$NON-NLS-1$
+  public static final String ALL_ARGUMENT = CommandLineConstants.ALL_ARGUMENT;
 
   public DefaultCommandLine() {
     argHelper = CommandLineArgumentHelper.getInstance();
@@ -74,59 +76,183 @@ public class DefaultCommandLine extends AbstractCommandLine {
   }
 
   protected void importProjects() throws CommandLineException {
-    String projectsToImport = argHelper.getImportProjects();
-    if (projectsToImport != null) {
-      try {
-        importProjects(toList(projectsToImport));
-      } catch (CoreException exception) {
-        throw new CommandLineException(exception.getMessage());
+    List<String> projectList = new ArrayList<>();
+    try {
+      String projectsToImport = argHelper.getImportProjects();
+      if (projectsToImport != null) {
+        projectList.addAll(toList(projectsToImport));
       }
+      String allProjectsToImport = argHelper.getImportAllProjects();
+      if (allProjectsToImport != null) {
+        projectList.addAll(getAllProjectsInFolder(allProjectsToImport));
+      }
+      importProjects(projectList);
+    } catch (CoreException | IOException exception) {
+      throw new CommandLineException(exception.getMessage());
     }
   }
 
   @Override
   public void postExecute(IApplicationContext context) throws CommandLineException {
-    exportZips();
-  }
-
-  protected void exportZips() throws CommandLineException {
-    String projectsToExportZip = argHelper.getExportZips();
-    if (projectsToExportZip != null) {
-      if (projectsToExportZip.equals(ALL_ARGUMENT)) {
-        exportProjectZips(Arrays.stream(ResourcesPlugin.getWorkspace().getRoot().getProjects())
-            .filter(CapellaResourceHelper::isCapellaProject).map(iProject -> iProject.getName())
-            .collect(Collectors.toList()));
-      } else {
-        exportProjectZips(toList(projectsToExportZip));
-      }
-    }
+    legacyExportZips();
+    exportProjects();
   }
 
   /**
-   * @param projectsToExportZip
-   * @throws CoreException
+   * Retrieves projects from a single text using 
+   * 
+   * @param names
+   * @return
    */
-  protected void exportProjectZips(List<String> projectsToExportZip) throws CommandLineException {
+  private List<IProject> getCapellaProjects(String names) {
+    if (names == null) {
+      return List.of();
+    }
+    
+    IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+        
+    if (names.equals(ALL_ARGUMENT)) {
+      return Arrays.stream(root.getProjects())
+          .filter(CapellaResourceHelper::isCapellaProject)
+          .collect(Collectors.toList());
+    }
+    return toList(names)
+        .stream()
+        .map(root::getProject)
+        .filter(project -> {
+          boolean result = project.exists() && project.isOpen();
+          if (!result) {
+            logger.error(Messages.export_zip_not_found + project);
+          }
+          return result;
+        })
+        .collect(Collectors.toList());
+  }
+
+  
+  /**
+   * Exports specified projects using legacy options.
+   * 
+   * @throws CommandLineException if export fails
+   */
+  protected void legacyExportZips() throws CommandLineException {
+    List<IProject> projects = getCapellaProjects(argHelper.getExportZips());
+    if (projects.isEmpty()) { // Nothing to export
+      return;
+    }
+
     IFolder outputFolder = getOrCreateOutputFolder();
     if (outputFolder == null) {
       logger.error(Messages.export_zip_no_ouputfolder);
     } else {
-      IProject[] iProjects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-      for (String project : projectsToExportZip) {
-        Optional<IProject> anyIProject = Arrays.stream(iProjects).filter(iProject -> iProject.getName().equals(project))
-            .findAny();
-        if (!anyIProject.isPresent()) {
-          logger.error(Messages.export_zip_not_found + project);
-        } else {
-          IWorkspace workspace = ResourcesPlugin.getWorkspace();
-          IFile file = outputFolder.getFile(project + ".zip"); //$NON-NLS-1$
-          IProject newProject = workspace.getRoot().getProject(project);
-          WorkbenchHelper.exportZipFile(newProject, file);
+      for (IProject project : projects) {
+          IFile file = outputFolder.getFile(project.getName() + ".zip"); //$NON-NLS-1$
+          WorkbenchHelper.exportZipFile(project, file);
+      }
+    }
+  }
+  
+  /**
+   * Exports specified projects.
+   * 
+   * @throws CommandLineException if export fails
+   */
+  protected void exportProjects() throws CommandLineException {
+    List<IProject> projectsToExport = getCapellaProjects(argHelper.getExportProjects());
+
+    if (!projectsToExport.isEmpty()) {
+      if (argHelper.isSingleZip()) {
+        exportProjectsAsSingleZip(projectsToExport);
+      } else if (argHelper.isExportCopy()) {
+        exportProjectsAsCopy(projectsToExport);
+      } else { // default export mode
+        exportProjectsAsZip(projectsToExport);
+      }
+    }
+  }
+  
+  /**
+   * Exports all projects as a folder copy.
+   * 
+   * @param projects list of projects
+   * @throws CommandLineException if export fails
+   */
+  protected void exportProjectsAsCopy(List<IProject> projects) throws CommandLineException {
+    File targetFolder = getExportTarget(true);
+    if (targetFolder != null) {
+      for (IProject project : projects) {
+        try {
+          FileUtils.copyDirectory(project.getLocation().toFile(), new File(targetFolder, project.getName()));
+        } catch (IOException e) {
+          throw new CommandLineException(Messages.cannot_create_folder);
         }
       }
     }
   }
+  
+  /**
+   * Exports all projects in a Zip file.
+   * 
+   * @param projects list of projects
+   * @throws CommandLineException if export fails
+   */
+  protected void exportProjectsAsSingleZip(List<IProject> projects) throws CommandLineException {
+    File targetZip = getExportTarget(false);
+    if (targetZip != null) {
+      WorkbenchHelper.exportZipFile(projects, targetZip.getAbsolutePath());
+    }
+  }
+  
+  /**
+   * Exports each projects in Zip file.
+   * 
+   * @param projects list of projects
+   * @throws CommandLineException if export fails
+   */
+  protected void exportProjectsAsZip(List<IProject> projects) throws CommandLineException {
+      File targetFolder = getExportTarget(true);
+      if (targetFolder != null) {
+        for (IProject project : projects) {
+          WorkbenchHelper.exportZipFile(List.of(project), new File(targetFolder, project.getName() + ".zip").getAbsolutePath());
+        }
+      }
+  }
 
+  
+  /**
+   * Gets the target of location for export.
+   * <p>
+   * This method ensures the container exists.
+   * </p>
+   * 
+   * @param isDirectory true if target if a folder.
+   * @return target of export
+   * @throws CommandLineException
+   */
+  private File getExportTarget(boolean isDirectory) throws CommandLineException {
+    String input = argHelper.getExportTarget();
+
+    if (input == null) {
+      logger.error(Messages.export_zip_no_ouputfolder);
+      return null;
+    }
+
+    File result = null;
+    java.nio.file.Path inputValue = Paths.get(input);
+    if (inputValue.isAbsolute()) {
+      result = new File(input);
+      File targetFolder = isDirectory ? result : result.getParentFile();
+      if (!targetFolder.isDirectory() && !targetFolder.mkdirs()) {
+        logger.error(Messages.cannot_create_folder, null);
+        throw new CommandLineException(Messages.cannot_create_folder);
+      }
+    } else {
+      result = getOrCreateOutputContainer(inputValue, isDirectory);
+    }
+    return result;
+  }
+
+  
   protected void checkProject(IProject project) throws CommandLineException {
     if (!project.exists()) {
       logError(Messages.project + project.getName() + Messages.not_exist);
@@ -167,8 +293,17 @@ public class DefaultCommandLine extends AbstractCommandLine {
         }
       }
     }
+    if (!isBlank(argHelper.getExportProjects()) && isBlank(argHelper.getExportTarget())) {
+      throw new CommandLineException(CommandLineConstants.EXPORT_TARGET
+          + " option is required when using "
+          + CommandLineConstants.EXPORT_LIST);
+    }
   }
 
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+  
   protected void checkInputProject(String projectPath) throws CommandLineException {
     String projectName = getProjectNameFromPath(projectPath);
     IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
@@ -188,17 +323,49 @@ public class DefaultCommandLine extends AbstractCommandLine {
   }
 
   /**
-   * @param outputFolder
+   * Creates the container if not existing and open it from specified path.
+   * 
+   * @param inputValue path of element to get
+   * @param isDirectory true if the element is folder or project
+   * @return associated file
    * @throws CommandLineException
    */
-  protected IFolder getOrCreateOutputFolder() throws CommandLineException {
-    String outputFolder = argHelper.getOutputFolder();
-    IFolder folder = null;
-    if (outputFolder != null) {
-      folder = ResourcesPlugin.getWorkspace().getRoot().getFolder(new Path(outputFolder));
-
-      try {
-        IProject project = folder.getProject();
+  protected File getOrCreateOutputContainer(java.nio.file.Path inputValue, boolean isDirectory) throws CommandLineException {
+    IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+    
+    File result;
+    if (inputValue.getNameCount() == 1) {
+      String filename = inputValue.getFileName().toString();
+      
+      if (!isDirectory) {
+        result = new File(root.getLocation().toFile(), filename);
+      } else {
+        IProject project = openOrCreateContainer(root.getProject(filename));
+        result = project.getLocation().toFile();
+      }
+    } else if (isDirectory) {
+      IFolder folder = openOrCreateContainer(root.getFolder(new Path(inputValue.toString())));
+      result = folder.getLocation().toFile();
+    } else {
+      IFile file = root.getFile(new Path(inputValue.toString()));
+      openOrCreateContainer(file.getParent());
+      result = file.getLocation().toFile();
+    }
+    return result;
+  }
+  
+  /**
+   * Create the container if not existing and open it.
+   * 
+   * @param <C> type of container
+   * @param container element to create
+   * @return provided container
+   * @throws CommandLineException if container cannot be created du to invalid value.
+   */
+  protected <C extends IContainer> C openOrCreateContainer(C container) throws CommandLineException {
+    try {
+      if (container instanceof IProject) {
+        IProject project = (IProject) container;
         if (!project.exists()) {
           project.create(new NullProgressMonitor());
         }
@@ -206,17 +373,38 @@ public class DefaultCommandLine extends AbstractCommandLine {
         if (!project.isOpen()) {
           project.open(new NullProgressMonitor());
         }
+      } else if (container instanceof IFolder) {
+        IFolder folder = (IFolder) container;
+        openOrCreateContainer(folder.getProject());
         if (!folder.exists()) {
           folder.create(true, true, new NullProgressMonitor());
         }
-      } catch (CoreException exception) {
-        StringBuilder message = new StringBuilder(Messages.cannot_create_folder);
-        logger.error(message.toString(), exception);
-        throw new CommandLineException(message.toString());
       }
+
+    } catch (CoreException exception) {
+      logger.error(Messages.cannot_create_folder, exception);
+      throw new CommandLineException(Messages.cannot_create_folder);
+    }
+    return container;
+  }
+
+  
+  /**
+   * Gets the output from argument.
+   * <p>
+   * Folder is created if necessary.
+   * </p>
+   * 
+   * @throws CommandLineException if folder cannot be created du to invalid value.
+   */
+  protected IFolder getOrCreateOutputFolder() throws CommandLineException {
+    String outputFolder = argHelper.getOutputFolder();
+    if (outputFolder != null) {
+      IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+      return openOrCreateContainer(root.getFolder(new Path(outputFolder)));
     }
 
-    return folder;
+    return null;
   }
 
   /**

--- a/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/WorkbenchHelper.java
+++ b/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/WorkbenchHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2026 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.polarsys.capella.core.commandline.core;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
@@ -26,18 +27,40 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.runtime.CoreException;
 
 /**
- *
+ * Helper class to transform Workbench data.
  */
 public class WorkbenchHelper {
    
   private static final Logger logger = Logger.getLogger(WorkbenchHelper.class.getName());
-	
+  
   private WorkbenchHelper () {
-	  // To hide the implicit public one
+    // To hide the implicit public one
   }
 
+  /**
+   * Exports the resource in a Zip file.
+   * <p>
+   * If a resource is a container, included resources is also added to the archive.
+   * </p>
+   * 
+   * @param resource content to compress
+   * @param theZipFile target file
+   */
   public static void exportZipFile(IResource resource, IFile theZipFile) {
-    try (final FileOutputStream fos = new FileOutputStream(theZipFile.getLocation().toOSString()); final ZipOutputStream zos = new ZipOutputStream(fos)) {
+    exportZipFile(List.of(resource), theZipFile.getLocation().toOSString());
+  }
+
+  /**
+   * Exports set of resources in a Zip file.
+   * <p>
+   * If a resource is a container, included resources is also added to the archive.
+   * </p>
+   * 
+   * @param sources element to archive
+   * @param targetZipFile path of file
+   */
+  public static void exportZipFile(List<? extends IResource> sources, String targetZipFile) {
+    try (final FileOutputStream fos = new FileOutputStream(targetZipFile); final ZipOutputStream zos = new ZipOutputStream(fos)) {
 
       IResourceVisitor visitor = new IResourceVisitor() {
 
@@ -55,16 +78,18 @@ public class WorkbenchHelper {
               zos.closeEntry();
             }
           } catch (IOException exception) {
-        	//Catch exception silently,
+          //Catch exception silently,
           }
           return true;
         }
       };
       
-      resource.accept(visitor);
-
+      for (IResource source : sources) {
+          source.accept(visitor);
+       }
+      
     } catch (Exception exception) {
-    	logger.log(Level.SEVERE, exception.getMessage(), exception);
+      logger.log(Level.SEVERE, exception.getMessage(), exception);
     }
   }
 }

--- a/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/messages.properties
+++ b/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/messages.properties
@@ -36,4 +36,4 @@ import_mandatory=Import argument is mandatory!
 inputs_mandatory=Inputs argument is mandatory!
 aird_not_found=Cannot find aird file in project:
 export_zip_not_found=Cannot find project to export:
-export_zip_no_ouputfolder=Output folder to export projects is not defined.
+export_zip_no_ouputfolder=Output folder or path to export projects is not defined.

--- a/doc/plugins/org.polarsys.capella.commandline.doc/html/19. Command Line Support/19.1. Core Mechanism and Applications.html
+++ b/doc/plugins/org.polarsys.capella.commandline.doc/html/19. Command Line Support/19.1. Core Mechanism and Applications.html
@@ -29,12 +29,24 @@
 			<tr>
 				<td>input</td>
 				<td>mandatory</td>
-				<td>defines a list of the relative paths (to the workspace) of the Eclipse projects or aird files to use as input of the command line. The list have to be placed into quotes "" and separated by a &#124; character. Use /all to specify that all projects in the workspace are used as input.</td>
+				<td>defines a list of the relative paths (to the workspace) of the Eclipse projects or aird files to use as input of the command line. The list have to be placed into quotes "" and separated by a 
+					<b>&#124;</b> character. Use 
+					<b>/all</b> to specify that all projects in the workspace are used as input.
+				</td>
 			</tr>
 			<tr>
 				<td>import</td>
 				<td>optional</td>
-				<td>defines a list of the path of the Eclipse projects to import into the workspace before doing the actual job. The list have to be placed into quotes "" and separated by a &#124; character</td>
+				<td>defines a list of the path of the Eclipse projects to import into the workspace before doing the actual job. The list have to be placed into quotes "" and separated by a 
+					<b>&#124;</b> character
+				</td>
+			</tr>
+			<tr>
+				<td>importAll</td>
+				<td>optional</td>
+				<td>defines a folder containing Eclipse Projects. The Eclipse projects can be a folder with a 
+					<i>.project</i> file or in a ZIP file.
+				</td>
 			</tr>
 			<tr>
 				<td>forceimport</td>
@@ -47,9 +59,47 @@
 				<td>defines the relative path (to the workspace) of the output folder</td>
 			</tr>
 			<tr>
+				<td>exportProjects</td>
+				<td>optional</td>
+				<td>defines a list of Eclipse projects to export by their names. The list have to be placed into quotes "" and separated by a 
+					<b>&#124;</b> character. Use 
+					<b>/all</b> to specify that all projects in the workspace are exported. The export behavior depends of 
+					<b>-exportCopy</b> and 
+					<b>-singleZip</b>. This parameter must be used with 
+					<b>-exportTarget</b> to specify where projects are exported.
+				</td>
+			</tr>
+			<tr>
+				<td>singleZip</td>
+				<td>optional</td>
+				<td>defines the location export. The location is a file if 
+					<b>-singleZip</b> is defined
+				</td>
+			</tr>
+			<tr>
+				<td>exportCopy</td>
+				<td>optional</td>
+				<td>defines the location export. The location is a file if 
+					<b>-singleZip</b> is defined
+				</td>
+			</tr>
+			<tr>
+				<td>exportTarget</td>
+				<td>optional</td>
+				<td>defines the location export. The location is a file if 
+					<b>-singleZip</b> is defined. Otherwize 
+				</td>
+			</tr>
+			<tr>
 				<td>exportZip</td>
 				<td>optional</td>
-				<td>defines a list of the relative paths of the Eclipse projects to export as zip. The list have to be placed into quotes "" and separated by a &#124; character. Use /all to specify that all projects in the workspace are exported. This parameter must be used with -outputfolder to specify the folder that contains the zips.</td>
+				<td>(Deprecated, see exportProjects option)
+					<p>defines a list of the relative paths of the Eclipse projects to export as zip. The list have to be placed into quotes "" and separated by a 
+						<b>&#124;</b> character. Use 
+						<b>/all</b> to specify that all projects in the workspace are exported. This parameter must be used with 
+						<b>-outputfolder</b> to specify the folder that contains the zips.
+					</p>
+				</td>
 			</tr>
 			<tr>
 				<td>nosplash</td>

--- a/doc/plugins/org.polarsys.capella.commandline.doc/html/19. Command Line Support/19.1. Core Mechanism and Applications.mediawiki
+++ b/doc/plugins/org.polarsys.capella.commandline.doc/html/19. Command Line Support/19.1. Core Mechanism and Applications.mediawiki
@@ -22,11 +22,15 @@ The core mechanism provides the following parameters:
 |-
 |input
 |mandatory
-|defines a list of the relative paths (to the workspace) of the Eclipse projects or aird files to use as input of the command line. The list have to be placed into quotes "" and separated by a &#124; character. Use /all to specify that all projects in the workspace are used as input.
+|defines a list of the relative paths (to the workspace) of the Eclipse projects or aird files to use as input of the command line. The list have to be placed into quotes "" and separated by a '''&#124;''' character. Use '''/all''' to specify that all projects in the workspace are used as input.
 |-
 |import
 |optional
-|defines a list of the path of the Eclipse projects to import into the workspace before doing the actual job. The list have to be placed into quotes "" and separated by a &#124; character
+|defines a list of the path of the Eclipse projects to import into the workspace before doing the actual job. The list have to be placed into quotes "" and separated by a '''&#124;''' character
+|-
+|importAll
+|optional
+|defines a folder containing Eclipse Projects. The Eclipse projects can be a folder with a ''.project'' file or in a ZIP file.
 |-
 |forceimport
 |optional
@@ -36,9 +40,26 @@ The core mechanism provides the following parameters:
 |optional
 |defines the relative path (to the workspace) of the output folder
 |-
+|exportProjects
+|optional
+|defines a list of Eclipse projects to export by their names. The list have to be placed into quotes "" and separated by a '''&#124;''' character. Use '''/all''' to specify that all projects in the workspace are exported. The export behavior depends of '''-exportCopy''' and '''-singleZip'''. This parameter must be used with '''-exportTarget''' to specify where projects are exported.
+|-
+|singleZip
+|optional
+|defines the location export. The location is a file if '''-singleZip''' is defined
+|-
+|exportCopy
+|optional
+|defines the location export. The location is a file if '''-singleZip''' is defined
+|-
+|exportTarget
+|optional
+|defines the location export. The location is a file if '''-singleZip''' is defined. Otherwize 
+|-
 |exportZip
 |optional
-|defines a list of the relative paths of the Eclipse projects to export as zip. The list have to be placed into quotes "" and separated by a &#124; character. Use /all to specify that all projects in the workspace are exported. This parameter must be used with -outputfolder to specify the folder that contains the zips.
+|(Deprecated, see exportProjects option)
+defines a list of the relative paths of the Eclipse projects to export as zip. The list have to be placed into quotes "" and separated by a '''&#124;''' character. Use '''/all''' to specify that all projects in the workspace are exported. This parameter must be used with '''-outputfolder''' to specify the folder that contains the zips.
 |-
 |nosplash
 |optional

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/testcases/AbstractCommandLineExportTestCase.java
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/testcases/AbstractCommandLineExportTestCase.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2026 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.commandline.ju.testcases;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.polarsys.capella.core.commandline.core.CommandLineConstants;
+import org.polarsys.capella.test.framework.api.BasicTestCase;
+
+/**
+ * Abstract class to test Export Projects options in commandline.
+ * 
+ * @author nicolas.peransin@obeo.fr
+ */
+public abstract class AbstractCommandLineExportTestCase extends BasicTestCase {
+
+  // private static final Path EXPORT_PATH = Path.of("target/test-run/DefaultCommandLineExportProjectTest");
+  private static final FileVisitor<Path> DELETOR = new SimpleFileVisitor<>() {
+    
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+      Files.delete(file);
+      return FileVisitResult.CONTINUE;
+    }
+
+    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+      Files.delete(dir);
+      return FileVisitResult.CONTINUE;      
+    }
+    
+  };
+
+  
+  protected static final String[] PROJECT_NAMES = {
+      "Test Command Line Validation", //$NON-NLS-1$
+      "RefreshRemoveExport" //$NON-NLS-1$
+  };
+  
+  protected static final Path WS_DATA_PATH = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile().toPath();
+  
+  /** Path where resources are exported. */
+  protected final Path[] exportPaths;
+  
+  protected AbstractCommandLineExportTestCase(Path... paths) {
+    exportPaths = paths;
+  }
+  
+  protected String listProject(String... project) {
+    return Stream.of(PROJECT_NAMES)
+      .map(this::getFolderInTestModelRepository)
+      .map(File::getAbsolutePath)
+      .collect(Collectors.joining(CommandLineConstants.LIST_SEPARATOR));
+  }
+  
+  
+  protected void cleanExportResources() throws IOException {
+    Stream.of(exportPaths)
+      .filter(Files::exists)
+      .forEach(path -> {
+        try {
+          Files.walkFileTree(path, DELETOR);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      });
+
+  }
+  
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    cleanExportResources();
+  }
+  
+  @Override
+  protected void tearDown() throws Exception {
+    try {
+      super.tearDown();
+    } finally {
+      cleanExportResources();
+    }
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/testcases/CommandLineExportProjectsAsFoldersTest.java
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/testcases/CommandLineExportProjectsAsFoldersTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.commandline.ju.testcases;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.polarsys.capella.core.commandline.core.CommandLineConstants;
+import org.polarsys.capella.core.commandline.core.DefaultCommandLine;
+import org.polarsys.capella.test.commandline.ju.utils.MockApplicationContext;
+
+/**
+ * Test Export project option in commandline.
+ * 
+ * @author nicolas.peransin@obeo.fr
+ */
+public class CommandLineExportProjectsAsFoldersTest extends AbstractCommandLineExportTestCase {
+
+  private static final Path EXPORT_PATH = Path.of("target/test-run/CommandLineExportProjectsAsFoldersTest");
+
+  /**
+   * Test constructor.
+   */
+  public CommandLineExportProjectsAsFoldersTest() {
+    super(EXPORT_PATH);
+  }
+  
+  
+  @Override
+  public void test() throws Exception {
+    MockApplicationContext.execute(new DefaultCommandLine() , "stub", 
+        CommandLineConstants.INPUT, CommandLineConstants.ALL_ARGUMENT,
+        CommandLineConstants.IMPORT, listProject(PROJECT_NAMES),
+        CommandLineConstants.EXPORT_LIST, CommandLineConstants.ALL_ARGUMENT,
+        CommandLineConstants.EXPORT_COPY,
+        CommandLineConstants.EXPORT_TARGET, EXPORT_PATH.toAbsolutePath().toString()
+        );
+    
+    for (String projectName : PROJECT_NAMES) {
+      var exportElement = EXPORT_PATH.resolve(projectName);
+      assertTrue("Fail to export Project as folder: " + projectName, Files.isDirectory(exportElement));
+    }
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/testcases/CommandLineExportProjectsAsSingleZipTest.java
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/testcases/CommandLineExportProjectsAsSingleZipTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2026 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.commandline.ju.testcases;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.polarsys.capella.core.commandline.core.CommandLineConstants;
+import org.polarsys.capella.core.commandline.core.DefaultCommandLine;
+import org.polarsys.capella.test.commandline.ju.utils.MockApplicationContext;
+
+/**
+ * Test Export project option in commandline.
+ * 
+ * @author nicolas.peransin@obeo.fr
+ */
+public class CommandLineExportProjectsAsSingleZipTest extends AbstractCommandLineExportTestCase {
+
+  private static final Path EXTERNAl_EXPORT_TARGET = Path.of("target/test-run/CommandLineExportProjectsAsSingleZipTest/projects.zip");
+  
+  private static final String RELATIVE_EXPORT_SEGMENT = "CommandLineExportProjectsAsSingleZipTest.zip";
+  // Path at the root of Workspace
+  private static final Path RELATIVE_EXPORT_TARGET = WS_DATA_PATH.resolve(RELATIVE_EXPORT_SEGMENT);
+
+
+  /**
+   * Test constructor.
+   */
+  public CommandLineExportProjectsAsSingleZipTest() {
+    super(EXTERNAl_EXPORT_TARGET.getParent(), RELATIVE_EXPORT_TARGET);
+  }
+  
+  @Override
+  public void test() throws Exception {
+    // External location
+    MockApplicationContext.execute(new DefaultCommandLine() , "stub", 
+        CommandLineConstants.INPUT, CommandLineConstants.ALL_ARGUMENT,
+        CommandLineConstants.IMPORT, listProject(PROJECT_NAMES),
+        CommandLineConstants.EXPORT_LIST, CommandLineConstants.ALL_ARGUMENT,
+        CommandLineConstants.SINGLE_ZIP,
+        CommandLineConstants.EXPORT_TARGET, EXTERNAl_EXPORT_TARGET.toAbsolutePath().toString()
+        );
+    
+    assertTrue(Files.exists(EXTERNAl_EXPORT_TARGET) && Files.size(EXTERNAl_EXPORT_TARGET) > 0);
+    
+    // Relative location
+    MockApplicationContext.execute(new DefaultCommandLine() , "stub", 
+        CommandLineConstants.INPUT, CommandLineConstants.ALL_ARGUMENT,
+        CommandLineConstants.IMPORT, listProject(PROJECT_NAMES),
+        CommandLineConstants.EXPORT_LIST, CommandLineConstants.ALL_ARGUMENT,
+        CommandLineConstants.SINGLE_ZIP,
+        CommandLineConstants.EXPORT_TARGET, RELATIVE_EXPORT_SEGMENT
+        );
+    
+    assertTrue(Files.exists(RELATIVE_EXPORT_TARGET) && Files.size(RELATIVE_EXPORT_TARGET) > 0);
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/testcases/CommandLineExportProjectsAsZipsTest.java
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/testcases/CommandLineExportProjectsAsZipsTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2026 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.commandline.ju.testcases;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.polarsys.capella.core.commandline.core.CommandLineConstants;
+import org.polarsys.capella.core.commandline.core.DefaultCommandLine;
+import org.polarsys.capella.test.commandline.ju.utils.MockApplicationContext;
+
+/**
+ * Test Export project option in commandline.
+ * 
+ * @author nicolas.peransin@obeo.fr
+ */
+public class CommandLineExportProjectsAsZipsTest extends AbstractCommandLineExportTestCase {
+
+  private static final Path EXTERNAl_EXPORT_PATH = Path.of("target/test-run/CommandLineExportProjectsAsZipsTest");
+  private static final String RELATIVE_EXPORT_SEGMENT = "CommandLineExportProjectsAsZipsTest/output";
+  private static final Path RELATIVE_EXPORT_PATH = WS_DATA_PATH.resolve(RELATIVE_EXPORT_SEGMENT);
+  
+
+  /**
+   * Test constructor.
+   */
+  public CommandLineExportProjectsAsZipsTest() {
+    super(EXTERNAl_EXPORT_PATH, RELATIVE_EXPORT_PATH);
+  }
+  
+  
+  @Override
+  public void test() throws Exception {
+    // External export
+    MockApplicationContext.execute(new DefaultCommandLine() , "stub", 
+        CommandLineConstants.INPUT, CommandLineConstants.ALL_ARGUMENT,
+        CommandLineConstants.IMPORT, listProject(PROJECT_NAMES),
+        CommandLineConstants.EXPORT_LIST, CommandLineConstants.ALL_ARGUMENT,
+        CommandLineConstants.EXPORT_TARGET, EXTERNAl_EXPORT_PATH.toAbsolutePath().toString()
+        );
+    
+    for (String projectName : PROJECT_NAMES) {
+      var exportFile = EXTERNAl_EXPORT_PATH.resolve(projectName + ".zip"); //$NON-NLS-1$
+      assertTrue("Fail to export Project as zip: " + projectName, Files.exists(exportFile) && Files.size(exportFile) > 0);
+    }
+    
+    // External export
+    MockApplicationContext.execute(new DefaultCommandLine() , "stub", 
+        CommandLineConstants.INPUT, CommandLineConstants.ALL_ARGUMENT,
+        CommandLineConstants.IMPORT, listProject(PROJECT_NAMES),
+        CommandLineConstants.EXPORT_LIST, CommandLineConstants.ALL_ARGUMENT,
+        CommandLineConstants.EXPORT_TARGET, RELATIVE_EXPORT_SEGMENT
+        );
+    
+    for (String projectName : PROJECT_NAMES) {
+      var exportFile = RELATIVE_EXPORT_PATH.resolve(projectName + ".zip"); //$NON-NLS-1$
+      assertTrue(Files.exists(exportFile) && Files.size(exportFile) > 0);
+    }
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/testsuites/CommandLineTestSuite.java
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/testsuites/CommandLineTestSuite.java
@@ -15,6 +15,9 @@ package org.polarsys.capella.test.commandline.ju.testsuites;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.polarsys.capella.test.commandline.ju.testcases.CommandLineExportProjectsAsFoldersTest;
+import org.polarsys.capella.test.commandline.ju.testcases.CommandLineExportProjectsAsSingleZipTest;
+import org.polarsys.capella.test.commandline.ju.testcases.CommandLineExportProjectsAsZipsTest;
 import org.polarsys.capella.test.commandline.ju.testcases.CommandLineExportRepresentationsTest;
 import org.polarsys.capella.test.commandline.ju.testcases.CommandLineFolderMigrationTest;
 import org.polarsys.capella.test.commandline.ju.testcases.CommandLineRefreshAirdTest;
@@ -27,17 +30,23 @@ import org.polarsys.capella.test.framework.api.BasicTestSuite;
 import junit.framework.Test;
 
 public class CommandLineTestSuite extends BasicTestSuite {
-
+  
   @Override
   protected List<BasicTestArtefact> getTests() {
-    List<BasicTestArtefact> tests = new ArrayList<>();
-    tests.add(new CommandLineValidationTest());
-    tests.add(new CommandLineZipMigrationTest());
-    tests.add(new CommandLineFolderMigrationTest());
-    tests.add(new CommandLineRemoveHiddenElementsTest());
-    tests.add(new CommandLineExportRepresentationsTest());
-    tests.add(new CommandLineRefreshAirdTest());
-    return tests;
+    return new ArrayList<>(List.of( // result must be mutable for BasicTestSuite.
+      // Common arguments tests
+      new CommandLineExportProjectsAsFoldersTest(),
+      new CommandLineExportProjectsAsSingleZipTest(),
+      new CommandLineExportProjectsAsZipsTest(),
+      
+      // Built-in command line tests
+      new CommandLineValidationTest(), 
+      new CommandLineZipMigrationTest(),
+      new CommandLineFolderMigrationTest(), 
+      new CommandLineRemoveHiddenElementsTest(),
+      new CommandLineExportRepresentationsTest(), 
+      new CommandLineRefreshAirdTest()
+     ));
   }
   
 

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/utils/MockApplicationContext.java
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/src/org/polarsys/capella/test/commandline/ju/utils/MockApplicationContext.java
@@ -15,10 +15,15 @@ package org.polarsys.capella.test.commandline.ju.utils;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
 import org.osgi.framework.Bundle;
+import org.polarsys.capella.core.commandline.core.CommandLineApp;
+import org.polarsys.capella.core.commandline.core.CommandLineConstants;
+import org.polarsys.capella.core.commandline.core.CommandLineException;
+import org.polarsys.capella.core.commandline.core.ICommandLine;
 
 /**
  * Mock implementation for IApplicationContext. Used to pass arguments when testing command line services.
@@ -27,7 +32,33 @@ public class MockApplicationContext implements IApplicationContext {
   // Mock application arguments
   private final Map<String, String[]> mockAppArguments;
   
-  public MockApplicationContext(String[] mockCommandLineArguments) {
+  
+  /**
+   * Executes the command line like in {@link CommandLineApp} for test purpose.
+   * 
+   * @param command to execute
+   * @param appId identification of the application
+   * @param arguments parameters of execution
+   * @throws CommandLineException if a step fails
+   */
+  public static void execute(ICommandLine command, String appId, String... arguments) throws CommandLineException {
+    IApplicationContext context = new MockApplicationContext(
+        Stream.concat(Stream.of(CommandLineConstants.ID, appId), Stream.of(arguments))
+          .toArray(String[]::new)
+        );
+    
+    // Sequence must be the same as in:
+    //   org.polarsys.capella.core.commandline.core.CommandLineApp
+    //   #launchApp(ICommandLine, IApplicationContext)
+
+    command.parseContext(context);
+    command.checkArgs(context);
+    command.prepare(context);
+    command.execute(context);
+    command.postExecute(context);
+  }
+  
+  public MockApplicationContext(String... mockCommandLineArguments) {
     Map<String, String[]> appArguments =  new HashMap<>();
     appArguments.put(IApplicationContext.APPLICATION_ARGS, mockCommandLineArguments);
     mockAppArguments = Collections.unmodifiableMap(appArguments);


### PR DESCRIPTION
- Add -importAll argument to the command line for project migration
- Add -exportProjects, -singleZip, -exportCopy option to deal with more formats when exporting data.

This options allows automatic update of SAAS platform.