### PR TITLE
[releng] Bump model version and test models to 7.1.0

### DIFF
--- a/core/plugins/org.polarsys.capella.core.af.integration/model/capella.vp
+++ b/core/plugins/org.polarsys.capella.core.af.integration/model/capella.vp
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<vp:Viewpoint xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:vp="http://www.polarsys.org/kitalpha/ad/viewpoint/1.0.0" name="Capella" id="org.polarsys.capella.core.viewpoint" vpid="capella" version="7.0.1">
+<vp:Viewpoint xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:vp="http://www.polarsys.org/kitalpha/ad/viewpoint/1.0.0" name="Capella" id="org.polarsys.capella.core.viewpoint" vpid="capella" version="7.1.0">
   <metamodel/>
   <representation/>
 </vp:Viewpoint>

--- a/core/plugins/org.polarsys.capella.core.data.migration/src/org/polarsys/capella/core/data/migration/contribution/ActivateDiagramFiltersContribution.java
+++ b/core/plugins/org.polarsys.capella.core.data.migration/src/org/polarsys/capella/core/data/migration/contribution/ActivateDiagramFiltersContribution.java
@@ -26,7 +26,7 @@ import org.polarsys.capella.core.sirius.analysis.helpers.DDiagramHelper;
 
 /**
  * This class activate filters for computed transitions on MSM diagrams. This contribution is only active for model
- * version 7.0.1.
+ * version anterior to 6.0.0.
  */
 public class ActivateDiagramFiltersContribution extends AbstractMigrationContribution {
 

--- a/samples/In-Flight Entertainment System/In-Flight Entertainment System.afm
+++ b/samples/In-Flight Entertainment System/In-Flight Entertainment System.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_2uVOAHjqEea__MYrXGSERA">
-  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.benchmarks.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.afm
+++ b/tests/plugins/org.polarsys.capella.test.benchmarks.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_2uVOAHjqEea__MYrXGSERA">
-  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysModelLib/sysModelLib.afm
+++ b/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysModelLib/sysModelLib.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_GH96wGHqEemeMahmZ8cB4Q">
-  <viewpointReferences id="_GIamsGHqEemeMahmZ8cB4Q" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_GIamsGHqEemeMahmZ8cB4Q" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/sysmodel.afm
+++ b/tests/plugins/org.polarsys.capella.test.business.queries.ju/model/sysmodel/sysmodel.afm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_NT6E8HTTEea2zdoadWNr2A">
-  <viewpointReferences id="_NT6E8XTTEea2zdoadWNr2A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_NT6E8XTTEea2zdoadWNr2A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
   <additionalMetadata href="../sysModelLib/sysModelLib.afm#_GH96wGHqEemeMahmZ8cB4Q"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/RefreshRemoveExport/RefreshRemoveExport.afm
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/RefreshRemoveExport/RefreshRemoveExport.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Zil2wFfXEeqln-XhR7jU9A">
-  <viewpointReferences id="_ZkrhcFfXEeqln-XhR7jU9A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_ZkrhcFfXEeqln-XhR7jU9A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/Test Command Line Validation/Test Command Line Validation.afm
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/Test Command Line Validation/Test Command Line Validation.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_FJH-AAmCEeef3_qOfMmJQw">
-  <viewpointReferences id="_GSWP4AmCEeef3_qOfMmJQw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_GSWP4AmCEeef3_qOfMmJQw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelLibrary_Sub/sysmodelLibrary_Sub.afm
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelLibrary_Sub/sysmodelLibrary_Sub.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_GyCssI-pEeagLJRD2VnG3A">
-  <viewpointReferences id="_GyCssY-pEeagLJRD2VnG3A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_GyCssY-pEeagLJRD2VnG3A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelLibrary_Super/sysmodelLibrary_Super.afm
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelLibrary_Super/sysmodelLibrary_Super.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_EzYnoI-pEeagLJRD2VnG3A">
-  <viewpointReferences id="_EzYnoY-pEeagLJRD2VnG3A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_EzYnoY-pEeagLJRD2VnG3A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/sysmodelProject.afm
+++ b/tests/plugins/org.polarsys.capella.test.commandline.ju/model/sysmodelProject/sysmodelProject.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_KBMJQI-pEeagLJRD2VnG3A">
-  <viewpointReferences id="_KBMJQY-pEeagLJRD2VnG3A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_KBMJQY-pEeagLJRD2VnG3A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/ElementLabelFilterModel/ElementLabelFilterModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/ElementLabelFilterModel/ElementLabelFilterModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_rmrkIFB0EembLZuYOQDZyg">
-  <viewpointReferences id="_sWqPkFB0EembLZuYOQDZyg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_sWqPkFB0EembLZuYOQDZyg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/HideFunctionalExchange/HideFunctionalExchange.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/HideFunctionalExchange/HideFunctionalExchange.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_evwmcO2XEeijUcDJRyD7mg">
-  <viewpointReferences id="_fHABwO2XEeijUcDJRyD7mg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_fHABwO2XEeijUcDJRyD7mg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/HideSimplifiedLinksFilter/HideSimplifiedLinksFilter.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/HideSimplifiedLinksFilter/HideSimplifiedLinksFilter.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_I8y8MGhyEeeJA6TBVgWePQ">
-  <viewpointReferences id="_I-qkcGhyEeeJA6TBVgWePQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_I-qkcGhyEeeJA6TBVgWePQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/InternalLinks/InternalLinks.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/InternalLinks/InternalLinks.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_jyC-8G0ZEeuBAeClabP96g">
-  <viewpointReferences id="_jzESoG0ZEeuBAeClabP96g" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_jzESoG0ZEeuBAeClabP96g" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/PB8/PB8.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/PB8/PB8.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_gpF9UJI-EeeH1vQ3EnstJA">
-  <viewpointReferences id="_g6WFYJI-EeeH1vQ3EnstJA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_g6WFYJI-EeeH1vQ3EnstJA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/PB9/PB9.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/PB9/PB9.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_WBJ40JI_EeeH1vQ3EnstJA">
-  <viewpointReferences id="_WBTCwJI_EeeH1vQ3EnstJA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_WBTCwJI_EeeH1vQ3EnstJA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Project_validation_hideControlNodesFilter/Project_validation_hideControlNodesFilter.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Project_validation_hideControlNodesFilter/Project_validation_hideControlNodesFilter.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_mWAewH8LEeaW0ceSBQc5Ww">
-  <viewpointReferences id="_nY8icH8LEeaW0ceSBQc5Ww" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_nY8icH8LEeaW0ceSBQc5Ww" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Project_validation_hideTechnicalInterfaceFilter/Project_validation_hideTechnicalInterfaceFilter.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Project_validation_hideTechnicalInterfaceFilter/Project_validation_hideTechnicalInterfaceFilter.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_3KiKUHnFEea0Df0HniJfuA">
-  <viewpointReferences id="_3KixYHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_3KixYHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/ShowTriggerSourceFunctionFilter/ShowTriggerSourceFunctionFilter.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/ShowTriggerSourceFunctionFilter/ShowTriggerSourceFunctionFilter.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_CHZP0LiYEeaEl8pe_NNa6A">
-  <viewpointReferences id="_CIrCMLiYEeaEl8pe_NNa6A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_CIrCMLiYEeaEl8pe_NNa6A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/StandardDiagramFiltersModel/StandardDiagramFiltersModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/StandardDiagramFiltersModel/StandardDiagramFiltersModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_9snugHulEemjMuz4grCl9A">
-  <viewpointReferences id="_9tEacHulEemjMuz4grCl9A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_9tEacHulEemjMuz4grCl9A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Test_delegationWizard/Test_delegationWizard.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/Test_delegationWizard/Test_delegationWizard.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_LzWBYHnGEea0Df0HniJfuA">
-  <viewpointReferences id="_LzXPgHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_LzXPgHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/TitleBlocksModel/TitleBlocksModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/TitleBlocksModel/TitleBlocksModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_0K8OAIXwEeqWaJq2mNMsRw">
-  <viewpointReferences id="_0Lr04IXwEeqWaJq2mNMsRw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_0Lr04IXwEeqWaJq2mNMsRw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/model2/model2.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/model2/model2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_ZRrgMJFUEeevSccoao4tJg">
-  <viewpointReferences id="_ZSIMIJFUEeevSccoao4tJg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_ZSIMIJFUEeevSccoao4tJg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/model3_multpart/model3_multpart.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.filters.ju/model/model3_multpart/model3_multpart.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_fLINwJF-EeeWAIhVXZef_g">
-  <viewpointReferences id="_fLk5sJF-EeeWAIhVXZef_g" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_fLk5sJF-EeeWAIhVXZef_g" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.layout.ju/model/FC/FC.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.layout.ju/model/FC/FC.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_dJjg0JAhEe2OYc1QJcaS8Q">
-  <viewpointReferences id="_dKmpsJAhEe2OYc1QJcaS8Q" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_dKmpsJAhEe2OYc1QJcaS8Q" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.layout.ju/model/modelCopyLayout/modelCopyLayout.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.layout.ju/model/modelCopyLayout/modelCopyLayout.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_N-uuMMfEEeifMqDVELmDAQ">
-  <viewpointReferences id="_N_x3EMfEEeifMqDVELmDAQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_N_x3EMfEEeifMqDVELmDAQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/Bug2579/Bug2579.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/Bug2579/Bug2579.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Hj2XQMVxEemLIOy5dk2dqQ">
-  <viewpointReferences id="_Hkl-IMVxEemLIOy5dk2dqQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Hkl-IMVxEemLIOy5dk2dqQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/DashFunctionBug/DashFunctionBug.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/DashFunctionBug/DashFunctionBug.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_P4fmsOYsEee0WpinHtEUew">
-  <viewpointReferences id="_P5YXgOYsEee0WpinHtEUew" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_P5YXgOYsEee0WpinHtEUew" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/DeleteFromModelWithTarget/DeleteFromModelWithTarget.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/DeleteFromModelWithTarget/DeleteFromModelWithTarget.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_7ulEwO51EemYsuV8o_AG9Q">
-  <viewpointReferences id="_7vK6oO51EemYsuV8o_AG9Q" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_7vK6oO51EemYsuV8o_AG9Q" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/EOLE_AF_UC/EOLE_AF_UC.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/EOLE_AF_UC/EOLE_AF_UC.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_ZtYRsIPqEeakXr_OCO8ayA">
-  <viewpointReferences id="_ZtaG4IPqEeakXr_OCO8ayA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_ZtaG4IPqEeakXr_OCO8ayA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/SBOrdering/SBOrdering.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/SBOrdering/SBOrdering.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_h3KwQK6lEeyjDbja2sGaGw">
-  <viewpointReferences id="_h39acK6lEeyjDbja2sGaGw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_h39acK6lEeyjDbja2sGaGw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/StatusLine/StatusLine.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/StatusLine/StatusLine.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_hBLyAIgeEeeGKdJkiNW8jQ">
-  <viewpointReferences id="_hB7Y4IgeEeeGKdJkiNW8jQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_hB7Y4IgeEeeGKdJkiNW8jQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/TestCloneDiagram/TestCloneDiagram.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/TestCloneDiagram/TestCloneDiagram.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_FLyuALtEEeiYJvO_5nNSmw">
-  <viewpointReferences id="_FMZK8LtEEeiYJvO_5nNSmw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_FMZK8LtEEeiYJvO_5nNSmw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/allocation-management/allocation-management.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/allocation-management/allocation-management.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_qy5R4FlAEeqh9rYvD3w64w">
-  <viewpointReferences id="_qzypwFlAEeqh9rYvD3w64w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_qzypwFlAEeqh9rYvD3w64w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1006/bug1006.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1006/bug1006.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_-DzpcH8OEeaitfKJsZ85kg">
-  <viewpointReferences id="_-D1eoH8OEeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_-D1eoH8OEeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1204/bug1204.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1204/bug1204.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_hqx04IWREeauLtN2qmw-qw">
-  <viewpointReferences id="_k1v8EIWREeauLtN2qmw-qw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_k1v8EIWREeauLtN2qmw-qw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1512/bug1512.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1512/bug1512.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_NLPdcApKEeeQwL0UBpxz_g">
-  <viewpointReferences id="_NLtXgApKEeeQwL0UBpxz_g" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_NLtXgApKEeeQwL0UBpxz_g" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1917/bug1917.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug1917/bug1917.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_jdNqkAJnEeid6-hE0Y2Esw">
-  <viewpointReferences id="_jfgwoAJnEeid6-hE0Y2Esw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_jfgwoAJnEeid6-hE0Y2Esw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug2047/bug2047.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/bug2047/bug2047.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_9k6UcDwIEei_tPbOC_qZag">
-  <viewpointReferences id="_9lduEDwIEei_tPbOC_qZag" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_9lduEDwIEei_tPbOC_qZag" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/component-breakdown/component-breakdown.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/component-breakdown/component-breakdown.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_XI2_oNktEemSZ_eLiRj6Iw">
-  <viewpointReferences id="_XJvwcNktEemSZ_eLiRj6Iw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_XJvwcNktEemSZ_eLiRj6Iw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/diagrams-having-parts-as-targets/diagrams-having-parts-as-targets.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/diagrams-having-parts-as-targets/diagrams-having-parts-as-targets.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_89c7cKKjEeuz-ecGGIJjJg">
-  <viewpointReferences id="_8-ePIKKjEeuz-ecGGIJjJg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_8-ePIKKjEeuz-ecGGIJjJg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/insert-remove-components-with-no-parts/insert-remove-simple.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/insert-remove-components-with-no-parts/insert-remove-simple.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_pwLk0ONZEem4uOAJj6D66w">
-  <viewpointReferences id="_pxX3oONZEem4uOAJj6D66w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_pxX3oONZEem4uOAJj6D66w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testPie/testPie.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testPie/testPie.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_EOxWIK-mEe6L-OKa_6GDIw">
-  <viewpointReferences id="_EmlZMK-mEe6L-OKa_6GDIw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_EmlZMK-mEe6L-OKa_6GDIw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testPortSize/testPortSize.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testPortSize/testPortSize.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_JaWHQHpWEeam2Za7kAFLHQ">
-  <viewpointReferences id="_JcVrUHpWEeam2Za7kAFLHQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_JcVrUHpWEeam2Za7kAFLHQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testRefreshContextualElements/testRefreshContextualElements.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.misc.ju/model/testRefreshContextualElements/testRefreshContextualElements.afm
@@ -4,5 +4,5 @@
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Mcvh4JdLEe2DZPU2bYNA6g">
   <viewpointReferences xsi:type="metadata:ViewpointReference" id="_MdIjcJdLEe2DZPU2bYNA6g"
-      vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+      vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/BlackInternalLinks/BlackInternalLinks.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/BlackInternalLinks/BlackInternalLinks.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_jyC-8G0ZEeuBAeClabP96g">
-  <viewpointReferences id="_jzESoG0ZEeuBAeClabP96g" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_jzESoG0ZEeuBAeClabP96g" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/CDBCommunication/CDBCommunication.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/CDBCommunication/CDBCommunication.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_pEjlcHs2EeaIfY15UCx5Ag">
-  <viewpointReferences id="_pEkzkHs2EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_pEkzkHs2EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Component-DragAndDrop/Component-DragAndDrop.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Component-DragAndDrop/Component-DragAndDrop.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_HsZ3AObfEeqg-uUChMfc-w">
-  <viewpointReferences id="_HtJd4ObfEeqg-uUChMfc-w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_HtJd4ObfEeqg-uUChMfc-w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/CompositeChains/CompositeChains.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/CompositeChains/CompositeChains.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_nKIucDEGEemiJKacZt74eQ">
-  <viewpointReferences id="_nRAygDEGEemiJKacZt74eQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_nRAygDEGEemiJKacZt74eQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ContextualInterface/ContextualInterface.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ContextualInterface/ContextualInterface.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_RrGEINuvEeqdae6AuBCEhA">
-  <viewpointReferences id="_Rr2SENuvEeqdae6AuBCEhA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Rr2SENuvEeqdae6AuBCEhA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramAction/DiagramAction.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramAction/DiagramAction.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_G0n6EAAMEeedEKRVkzurCQ">
-  <viewpointReferences id="_G1eOoAAMEeedEKRVkzurCQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_G1eOoAAMEeedEKRVkzurCQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramNavigationModel/DiagramNavigationModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramNavigationModel/DiagramNavigationModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_sD_doB_EEe23E9hag6DKPA">
-  <viewpointReferences id="_s5ydMB_EEe23E9hag6DKPA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_s5ydMB_EEe23E9hag6DKPA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramToolsModel/DiagramToolsModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DiagramToolsModel/DiagramToolsModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_U8E4gD5tEemFMbQILueuVQ">
-  <viewpointReferences id="_U80fYD5tEemFMbQILueuVQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_U80fYD5tEemFMbQILueuVQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DndTestModel/DndTestModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/DndTestModel/DndTestModel.afm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_MzNqYByQEe63IOsHcUKd0g">
-  <viewpointReferences id="_MzpvQByQEe63IOsHcUKd0g" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_MzpvQByQEe63IOsHcUKd0g" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
   <additionalMetadata href="../Library1/Library1.afm#_-9KvcBsBEe6B1PQ6uwGDXA"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ESProject/ESProject.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ESProject/ESProject.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_1-maAHs2EeaIfY15UCx5Ag">
-  <viewpointReferences id="_1-noIHs2EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_1-noIHs2EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/EmptyProject/EmptyProject.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/EmptyProject/EmptyProject.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_xg7U0Hs2EeaIfY15UCx5Ag">
-  <viewpointReferences id="_xg8i8Hs2EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_xg8i8Hs2EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/FCDCollapsingTest/FCDCollapsingTest.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/FCDCollapsingTest/FCDCollapsingTest.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_bBYYYDkTEem7yd1j6IxcgA">
-  <viewpointReferences id="_bBz2MDkTEem7yd1j6IxcgA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_bBz2MDkTEem7yd1j6IxcgA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/FunctionalChains/FunctionalChains.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/FunctionalChains/FunctionalChains.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_ACGeED8fEemAMorOl8q0FQ">
-  <viewpointReferences id="_AC2sAD8fEemAMorOl8q0FQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_AC2sAD8fEemAMorOl8q0FQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_2uVOAHjqEea__MYrXGSERA">
-  <viewpointReferences id="_fEEPwIoPEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_fEEPwIoPEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Library1/Library1.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Library1/Library1.afm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_-9KvcBsBEe6B1PQ6uwGDXA">
-  <viewpointReferences id="_-9anEBsBEe6B1PQ6uwGDXA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_-9anEBsBEe6B1PQ6uwGDXA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
   <additionalMetadata href="../Library2/Library2.afm#_NsSGIDB1Ee6PT_g4qXzOXA"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Library2/Library2.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/Library2/Library2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_NsSGIDB1Ee6PT_g4qXzOXA">
-  <viewpointReferences id="_NtDiMDB1Ee6PT_g4qXzOXA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_NtDiMDB1Ee6PT_g4qXzOXA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/MCBDiagramModel/MCBDiagramModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/MCBDiagramModel/MCBDiagramModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_AKp-UHs3EeaIfY15UCx5Ag">
-  <viewpointReferences id="_AKrMcHs3EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_AKrMcHs3EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/MSMComputedTransitions/MSMComputedTransitions.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/MSMComputedTransitions/MSMComputedTransitions.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_xPfp0HLIEey3iJoxDEayIQ">
-  <viewpointReferences id="_xP-yAHLIEey3iJoxDEayIQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_xP-yAHLIEey3iJoxDEayIQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ModelFC/ModelFC.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ModelFC/ModelFC.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_YK_kMDd2Eeq-M9wDCFbZqg">
-  <viewpointReferences id="_YLvLEDd2Eeq-M9wDCFbZqg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_YLvLEDd2Eeq-M9wDCFbZqg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/OAB-DragAndDrop.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/OAB-DragAndDrop.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_IUo5gObQEeqUc8Y6CrCvEA">
-  <viewpointReferences id="_IVZHcObQEeqUc8Y6CrCvEA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_IVZHcObQEeqUc8Y6CrCvEA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/PABDiagramModel/PABDiagramModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/PABDiagramModel/PABDiagramModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_GirQUHs3EeaIfY15UCx5Ag">
-  <viewpointReferences id="_GitFgHs3EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_GitFgHs3EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/PhysicalPathDisplay/PhysicalPathDisplay.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/PhysicalPathDisplay/PhysicalPathDisplay.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_lq6NgDMPEeu5xqfCZIUphQ">
-  <viewpointReferences id="_lreOMDMPEeu5xqfCZIUphQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_lreOMDMPEeu5xqfCZIUphQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ReuseOfComponentsModel/ReuseOfComponentsModel/ReuseOfComponentsModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ReuseOfComponentsModel/ReuseOfComponentsModel/ReuseOfComponentsModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_s0CHgP_NEemrtLxzTUEpLQ">
-  <viewpointReferences id="_s0ezcP_NEemrtLxzTUEpLQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_s0ezcP_NEemrtLxzTUEpLQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SABDiagramModel/SABDiagramModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SABDiagramModel/SABDiagramModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_MDIoMHs3EeaIfY15UCx5Ag">
-  <viewpointReferences id="_MDJ2UHs3EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_MDJ2UHs3EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SequenceDiagramProject/SequenceDiagramProject.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SequenceDiagramProject/SequenceDiagramProject.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_xg7U0Hs2EeaIfY15UCx5Ag">
-  <viewpointReferences id="_xg8i8Hs2EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_xg8i8Hs2EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ShowHideExchangesAndLinks/ShowHideExchangesAndLinks.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ShowHideExchangesAndLinks/ShowHideExchangesAndLinks.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_jGTsUANUEeeNn9XwfR6Gkg">
-  <viewpointReferences id="_jN9McANUEeeNn9XwfR6Gkg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_jN9McANUEeeNn9XwfR6Gkg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ShowHideFEModel/ShowHideFEModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ShowHideFEModel/ShowHideFEModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_6AgroBCkEeezd5MZBeXbXQ">
-  <viewpointReferences id="_6AmyQBCkEeezd5MZBeXbXQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_6AmyQBCkEeezd5MZBeXbXQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SwitchCategory/SwitchCategory.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SwitchCategory/SwitchCategory.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_XLA7kHs3EeaIfY15UCx5Ag">
-  <viewpointReferences id="_XLCJsHs3EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_XLCJsHs3EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SwitchCategoryHidingInternalEdges/SwitchCategoryHidingInternalEdges.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/SwitchCategoryHidingInternalEdges/SwitchCategoryHidingInternalEdges.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_FI8JcJynEeid1qo5XloxBw">
-  <viewpointReferences id="_FJsXYJynEeid1qo5XloxBw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_FJsXYJynEeid1qo5XloxBw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/TitleBlocksModel/TitleBlocksModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/TitleBlocksModel/TitleBlocksModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_1LfV8HJxEeqBQrAoig1yxA">
-  <viewpointReferences id="_1MrowHJxEeqBQrAoig1yxA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_1MrowHJxEeqBQrAoig1yxA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/XABDiagrams/XABDiagrams.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/XABDiagrams/XABDiagrams.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_NtwEUB4mEemefoIC0oWX6A">
-  <viewpointReferences id="_NuMwQB4mEemefoIC0oWX6A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_NuMwQB4mEemefoIC0oWX6A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/XDFBToolsTestingModel/XDFBToolsTestingModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/XDFBToolsTestingModel/XDFBToolsTestingModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_pKfDUB2DEemHuJx7zPYqqQ">
-  <viewpointReferences id="_pLBO0B2DEemHuJx7zPYqqQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_pLBO0B2DEemHuJx7zPYqqQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/opd-fcd-cycle-model/opd-fcd-cycle-model.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/opd-fcd-cycle-model/opd-fcd-cycle-model.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_N2RHgLFFEeqoD5VLzCQ3nw">
-  <viewpointReferences id="_N3BVcLFFEeqoD5VLzCQ3nw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_N3BVcLFFEeqoD5VLzCQ3nw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/opd-fcd-exchange-tool-cycle-model/opd-fcd-exchange-tool-cycle-model.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/opd-fcd-exchange-tool-cycle-model/opd-fcd-exchange-tool-cycle-model.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_N2RHgLFFEeqoD5VLzCQ3nw">
-  <viewpointReferences id="_N3BVcLFFEeqoD5VLzCQ3nw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_N3BVcLFFEeqoD5VLzCQ3nw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/test/test.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/test/test.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_PCuDMLpkEeeRxJoRAeHdNw">
-  <viewpointReferences id="_Pj2aULpkEeeRxJoRAeHdNw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Pj2aULpkEeeRxJoRAeHdNw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.explorer.activity.ju/model/EmptyModel/EmptyModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.explorer.activity.ju/model/EmptyModel/EmptyModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_oMOX8HnFEea0Df0HniJfuA">
-  <viewpointReferences id="_oMPmEHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_oMPmEHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.fastlinker.ju/model/TestsFastLinker/TestsFastLinker.afm
+++ b/tests/plugins/org.polarsys.capella.test.fastlinker.ju/model/TestsFastLinker/TestsFastLinker.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_tfbbsH8PEeaitfKJsZ85kg">
-  <viewpointReferences id="_tfefAH8PEeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_tfefAH8PEeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/sysmodel.afm
+++ b/tests/plugins/org.polarsys.capella.test.fragmentation/model/FragmentTestModel/sysmodel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Fhg5MG9NEeaS6s5ghsv39g">
-  <viewpointReferences id="_FhiHUG9NEeaS6s5ghsv39g" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_FhiHUG9NEeaS6s5ghsv39g" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary1/MyLibrary1.afm
+++ b/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary1/MyLibrary1.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_jebzIHnFEea0Df0HniJfuA">
-  <viewpointReferences id="_jedBQHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_jedBQHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary2/MyLibrary2.afm
+++ b/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary2/MyLibrary2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_idn2YHnFEea0Df0HniJfuA">
-  <viewpointReferences id="_idpEgHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_idpEgHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary3/MyLibrary3.afm
+++ b/tests/plugins/org.polarsys.capella.test.library.ju/model/MyLibrary3/MyLibrary3.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_nSproHnFEea0Df0HniJfuA">
-  <viewpointReferences id="_nSq5wHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_nSq5wHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.library.ju/model/MyProject1/MyProject1.afm
+++ b/tests/plugins/org.polarsys.capella.test.library.ju/model/MyProject1/MyProject1.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_UzLqMHnGEea0Df0HniJfuA">
-  <viewpointReferences id="_UzM4UHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_UzM4UHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.library.ju/model/MyProject2/MyProject2.afm
+++ b/tests/plugins/org.polarsys.capella.test.library.ju/model/MyProject2/MyProject2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Tku6EHnGEea0Df0HniJfuA">
-  <viewpointReferences id="_TkwIMHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_TkwIMHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary1/MyLibrary1.afm
+++ b/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary1/MyLibrary1.afm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_jebzIHnFEea0Df0HniJfuA">
-  <viewpointReferences id="_jedBQHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_jedBQHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
   <additionalMetadata href="../MyLibrary2/MyLibrary2.afm#_idn2YHnFEea0Df0HniJfuA"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary2/MyLibrary2.afm
+++ b/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary2/MyLibrary2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_idn2YHnFEea0Df0HniJfuA">
-  <viewpointReferences id="_idpEgHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_idpEgHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary3/MyLibrary3.afm
+++ b/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyLibrary3/MyLibrary3.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_nSproHnFEea0Df0HniJfuA">
-  <viewpointReferences id="_nSq5wHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_nSq5wHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyProject1/MyProject1.afm
+++ b/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyProject1/MyProject1.afm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_UzLqMHnGEea0Df0HniJfuA">
-  <viewpointReferences id="_UzM4UHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_UzM4UHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
   <additionalMetadata href="../MyLibrary1/MyLibrary1.afm#_jebzIHnFEea0Df0HniJfuA"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyProject2/MyProject2.afm
+++ b/tests/plugins/org.polarsys.capella.test.library.ui.ju/model/MyProject2/MyProject2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Tku6EHnGEea0Df0HniJfuA">
-  <viewpointReferences id="_TkwIMHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_TkwIMHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.massactions.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.afm
+++ b/tests/plugins/org.polarsys.capella.test.massactions.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_2uVOAHjqEea__MYrXGSERA">
-  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/ECM_Rapid_ImplementationNonRegression/ECM_Rapid_ImplementationNonRegression.afm
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/ECM_Rapid_ImplementationNonRegression/ECM_Rapid_ImplementationNonRegression.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_V3WxwPw1EeyhYpyGVxOiXg">
-  <viewpointReferences id="_V36LYPw1EeyhYpyGVxOiXg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_V36LYPw1EeyhYpyGVxOiXg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/FunctionalChainsNonRegression/FunctionalChainsNonRegression.afm
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/FunctionalChainsNonRegression/FunctionalChainsNonRegression.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_jlQfcEGOEemEkr4HpicQpA">
-  <viewpointReferences id="_jmJQQEGOEemEkr4HpicQpA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_jmJQQEGOEemEkr4HpicQpA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/activate-filters-6_0_0/activate-filters-6_0_0.afm
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/activate-filters-6_0_0/activate-filters-6_0_0.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_dFKjIG0MEeuoPYrzOa2sdQ">
-  <viewpointReferences id="_euEaoG0MEeuoPYrzOa2sdQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_euEaoG0MEeuoPYrzOa2sdQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/migration.sysmodel.afm
+++ b/tests/plugins/org.polarsys.capella.test.migration.ju/model/filter.sysmodel/migration.sysmodel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_v61M8FzTEeepGap1ToC6_Q">
-  <viewpointReferences id="_v68hsFzTEeepGap1ToC6_Q" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_v68hsFzTEeepGap1ToC6_Q" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/CopyPasteTestCase_Lib/CopyPasteTestCase_Lib.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/CopyPasteTestCase_Lib/CopyPasteTestCase_Lib.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_WWDZ8Jb6EeieV6BYnaPFSw">
-  <viewpointReferences id="_WWWU4Jb6EeieV6BYnaPFSw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_WWWU4Jb6EeieV6BYnaPFSw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/CopyPasteTestCase_Project/CopyPasteTestCase_Project.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/CopyPasteTestCase_Project/CopyPasteTestCase_Project.afm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_aW1HwJb6EeieV6BYnaPFSw">
-  <viewpointReferences id="_aXICsJb6EeieV6BYnaPFSw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_aXICsJb6EeieV6BYnaPFSw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
   <additionalMetadata href="../CopyPasteTestCase_Lib/CopyPasteTestCase_Lib.afm#_WWDZ8Jb6EeieV6BYnaPFSw"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/DiagramLabelModel/DiagramLabelModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/DiagramLabelModel/DiagramLabelModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_E86VEHnGEea0Df0HniJfuA">
-  <viewpointReferences id="_E87jMHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_E87jMHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourcePrj/DiffMergeSourcePrj.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourcePrj/DiffMergeSourcePrj.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_epRnYPcZEemoZuTI-rKb9Q">
-  <viewpointReferences id="_eqBOQPcZEemoZuTI-rKb9Q" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_eqBOQPcZEemoZuTI-rKb9Q" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourceT4CPrj/DiffMergeSourcePrj.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourceT4CPrj/DiffMergeSourcePrj.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_epRnYPcZEemoZuTI-rKb9Q">
-  <viewpointReferences id="_eqBOQPcZEemoZuTI-rKb9Q" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_eqBOQPcZEemoZuTI-rKb9Q" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourceV1Prj/DiffMergeSourcePrj.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourceV1Prj/DiffMergeSourcePrj.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_epRnYPcZEemoZuTI-rKb9Q">
-  <viewpointReferences id="_eqBOQPcZEemoZuTI-rKb9Q" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_eqBOQPcZEemoZuTI-rKb9Q" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeTargetPrj/DiffMergeTargetPrj.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeTargetPrj/DiffMergeTargetPrj.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_g9iwEPcZEemoZuTI-rKb9Q">
-  <viewpointReferences id="_g_Lu0PcZEemoZuTI-rKb9Q" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_g_Lu0PcZEemoZuTI-rKb9Q" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/ISMessage/ISMessage.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/ISMessage/ISMessage.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_xTOYsHnFEea0Df0HniJfuA">
-  <viewpointReferences id="_xTPm0HnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_xTPm0HnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/ObfuscateModelTestCase/ObfuscateModelTestCase.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/ObfuscateModelTestCase/ObfuscateModelTestCase.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_85A-kO0dEea3puAT08GMUQ">
-  <viewpointReferences id="_85yaoO0dEea3puAT08GMUQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_85yaoO0dEea3puAT08GMUQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/RenameModel/RenameModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/RenameModel/RenameModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_N7jEAHnGEea0Df0HniJfuA">
-  <viewpointReferences id="_N7kSIHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_N7kSIHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/SemanticDnd/SemanticDnd.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/SemanticDnd/SemanticDnd.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Ya6mcGrbEeuF9LmJx6sPIg">
-  <viewpointReferences id="_YbkGsGrbEeuF9LmJx6sPIg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_YbkGsGrbEeuF9LmJx6sPIg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/[rename model]/[rename model].afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/[rename model]/[rename model].afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_a3JkwCpjEeump7YteFkpuQ">
-  <viewpointReferences id="_a4XFsCpjEeump7YteFkpuQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_a4XFsCpjEeump7YteFkpuQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/capabilityExt/capabilityExt.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/capabilityExt/capabilityExt.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_y7WU8OLjEeqvEf_H_BOEBA">
-  <viewpointReferences id="_y78x4OLjEeqvEf_H_BOEBA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_y78x4OLjEeqvEf_H_BOEBA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/copyPasteLayout/copyPasteLayout.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/copyPasteLayout/copyPasteLayout.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_uD-OcHnFEea0Df0HniJfuA">
-  <viewpointReferences id="_uD_ckHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_uD_ckHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/detach_lib/version_ok/p1.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/detach_lib/version_ok/p1.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_N5CnUH8QEeaitfKJsZ85kg">
-  <viewpointReferences id="_N5EcgH8QEeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_N5EcgH8QEeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-library/gch-library.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-library/gch-library.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_PK1X4JO8Eeub39hF3nbpBA">
-  <viewpointReferences id="_PLVHIJO8Eeub39hF3nbpBA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_PLVHIJO8Eeub39hF3nbpBA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-project/gch-project.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/gch-project/gch-project.afm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_NvZUoJO8Eeub39hF3nbpBA">
-  <viewpointReferences id="_NwDb8JO8Eeub39hF3nbpBA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_NwDb8JO8Eeub39hF3nbpBA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
   <additionalMetadata href="../gch-library/gch-library.afm#_PK1X4JO8Eeub39hF3nbpBA"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/L1/L1.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/L1/L1.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_yNpo4H8QEeaitfKJsZ85kg">
-  <viewpointReferences id="_yNsFIH8QEeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_yNsFIH8QEeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/L2/L2.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/L2/L2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="__8W0kH8QEeaitfKJsZ85kg">
-  <viewpointReferences id="__8YpwH8QEeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="__8YpwH8QEeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/LIB/LIB.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/LIB/LIB.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_FZlSQH8REeaitfKJsZ85kg">
-  <viewpointReferences id="_FZnugH8REeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_FZnugH8REeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/P/P.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/P/P.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_LtA_MH8REeaitfKJsZ85kg">
-  <viewpointReferences id="_LtDbcH8REeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_LtDbcH8REeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/PROJECT/PROJECT.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/intermodelInconsistencies/PROJECT/PROJECT.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_OUpv0H8REeaitfKJsZ85kg">
-  <viewpointReferences id="_OUrlAH8REeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_OUrlAH8REeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/lcdecomposition/lcdecomposition.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/lcdecomposition/lcdecomposition.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_HZo2MHnGEea0Df0HniJfuA">
-  <viewpointReferences id="_HZqEUHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_HZqEUHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/miscmodel/miscmodel.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/miscmodel/miscmodel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_QfEJoHnGEea0Df0HniJfuA">
-  <viewpointReferences id="_QfFXwHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_QfFXwHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/renameTest 1  2/renameTest 1  2.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/renameTest 1  2/renameTest 1  2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_o20nIPxrEeinZJ38EPcn1w">
-  <viewpointReferences id="_o3adAPxrEeinZJ38EPcn1w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_o3adAPxrEeinZJ38EPcn1w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/sortcontent/sortcontent.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/sortcontent/sortcontent.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Jmbd4HnGEea0Df0HniJfuA">
-  <viewpointReferences id="_JmcsAHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_JmcsAHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/test_B/test_B.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/test_B/test_B.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_SKLIoBETEeq9ZqTHta-aWA">
-  <viewpointReferences id="_SKeDkBETEeq9ZqTHta-aWA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_SKeDkBETEeq9ZqTHta-aWA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/test_C/test_C.afm
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/test_C/test_C.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Tu6R0BETEeq9ZqTHta-aWA">
-  <viewpointReferences id="_TvNz0BETEeq9ZqTHta-aWA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_TvNz0BETEeq9ZqTHta-aWA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.navigator.ju/model/Component-Part-ComponentPkg-DragAndDrop/Component-Part-ComponentPkg-DragAndDrop.afm
+++ b/tests/plugins/org.polarsys.capella.test.navigator.ju/model/Component-Part-ComponentPkg-DragAndDrop/Component-Part-ComponentPkg-DragAndDrop.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_HsZ3AObfEeqg-uUChMfc-w">
-  <viewpointReferences id="_HtJd4ObfEeqg-uUChMfc-w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_HtJd4ObfEeqg-uUChMfc-w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.navigator.ju/model/NavigableElements/NavigableElements.afm
+++ b/tests/plugins/org.polarsys.capella.test.navigator.ju/model/NavigableElements/NavigableElements.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_3qQGcONuEemL4ckQ_VYijw">
-  <viewpointReferences id="_3qjocONuEemL4ckQ_VYijw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_3qjocONuEemL4ckQ_VYijw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.navigator.ju/model/NavigatorEmptyProject/NavigatorEmptyProject.afm
+++ b/tests/plugins/org.polarsys.capella.test.navigator.ju/model/NavigatorEmptyProject/NavigatorEmptyProject.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_qcfKYHnFEea0Df0HniJfuA">
-  <viewpointReferences id="_qcgYgHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_qcgYgHnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.navigator.ju/model/emptyDiagram/emptyDiagram.afm
+++ b/tests/plugins/org.polarsys.capella.test.navigator.ju/model/emptyDiagram/emptyDiagram.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_UCbcUPbzEeiLpslvQua1lw">
-  <viewpointReferences id="_URoV8PbzEeiLpslvQua1lw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_URoV8PbzEeiLpslvQua1lw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/TestNavigationDoubleClick.afm
+++ b/tests/plugins/org.polarsys.capella.test.platform.ju/model/TestNavigationDoubleClick/TestNavigationDoubleClick.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_gsWC4Nr8Ee6g1ac8T6chTw">
-  <viewpointReferences id="_gtBYUNr8Ee6g1ac8T6chTw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_gtBYUNr8Ee6g1ac8T6chTw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.afm
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/model/In-Flight Entertainment System/In-Flight Entertainment System.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_2uVOAHjqEea__MYrXGSERA">
-  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/model/setProgress/setProgress.afm
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/model/setProgress/setProgress.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Sp1YEHnGEea0Df0HniJfuA">
-  <viewpointReferences id="_Sp2mMHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Sp2mMHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.projection.ju/model/FunctionalChain/FunctionalChain.afm
+++ b/tests/plugins/org.polarsys.capella.test.projection.ju/model/FunctionalChain/FunctionalChain.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_iqbL4EWEEe24t8fF29Jotw">
-  <viewpointReferences id="_iq_zoEWEEe24t8fF29Jotw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_iq_zoEWEEe24t8fF29Jotw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.projection.ju/model/testInterfacesFromAllocatedFunctions/testInterfacesFromAllocatedFunctions.afm
+++ b/tests/plugins/org.polarsys.capella.test.projection.ju/model/testInterfacesFromAllocatedFunctions/testInterfacesFromAllocatedFunctions.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_red4ICkGEeeN0Jj8LM0KEQ">
-  <viewpointReferences id="_reyBMCkGEeeN0Jj8LM0KEQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_reyBMCkGEeeN0Jj8LM0KEQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/MassActions/model/In-Flight Entertainment System/In-Flight Entertainment System.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/MassActions/model/In-Flight Entertainment System/In-Flight Entertainment System.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_2uVOAHjqEea__MYrXGSERA">
-  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/Bug2242/Bug2242.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/Bug2242/Bug2242.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_T4broNdeEeiv0MCZCDcVww">
-  <viewpointReferences id="_T43wgNdeEeiv0MCZCDcVww" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_T43wgNdeEeiv0MCZCDcVww" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/ConstraintEdition/ConstraintEdition.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/ConstraintEdition/ConstraintEdition.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_tc6tICmbEeet0P8uzCNCFQ">
-  <viewpointReferences id="_tdXZECmbEeet0P8uzCNCFQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_tdXZECmbEeet0P8uzCNCFQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/CopyPasteNoDuplicate/CopyPasteNoDuplicate.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/CopyPasteNoDuplicate/CopyPasteNoDuplicate.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_aHU4sFfEEemF3sfUyFe1fQ">
-  <viewpointReferences id="_aHnzoFfEEemF3sfUyFe1fQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_aHnzoFfEEemF3sfUyFe1fQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DeleteLifeline/DeleteLifeline.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DeleteLifeline/DeleteLifeline.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Bi0isDWVEeegO75wgtaLyw">
-  <viewpointReferences id="_BjYjYDWVEeegO75wgtaLyw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_BjYjYDWVEeegO75wgtaLyw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiagramNavigationModel/OnDoubleClick/DiagramNavigationModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiagramNavigationModel/OnDoubleClick/DiagramNavigationModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_sD_doB_EEe23E9hag6DKPA">
-  <viewpointReferences id="_s5ydMB_EEe23E9hag6DKPA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_s5ydMB_EEe23E9hag6DKPA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_1/TestModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_1/TestModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_sQLAcEJOEei5Pfkv4wYo9A">
-  <viewpointReferences id="_sQnsYEJOEei5Pfkv4wYo9A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_sQnsYEJOEei5Pfkv4wYo9A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_2/TestModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_Fragment_Model_Import_2/TestModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_sQLAcEJOEei5Pfkv4wYo9A">
-  <viewpointReferences id="_sQnsYEJOEei5Pfkv4wYo9A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_sQnsYEJOEei5Pfkv4wYo9A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_TestModel_Import_1/TestModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_TestModel_Import_1/TestModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_sQLAcEJOEei5Pfkv4wYo9A">
-  <viewpointReferences id="_sQnsYEJOEei5Pfkv4wYo9A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_sQnsYEJOEei5Pfkv4wYo9A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_TestModel_Import_2/TestModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/DiffMerge_TestModel_Import_2/TestModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_sQLAcEJOEei5Pfkv4wYo9A">
-  <viewpointReferences id="_sQnsYEJOEei5Pfkv4wYo9A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_sQnsYEJOEei5Pfkv4wYo9A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/EOLE_AF/EOLE_AF.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/EOLE_AF/EOLE_AF.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_f9PgIHnMEeaDm6xzweMlog">
-  <viewpointReferences id="_f9YqEHnMEeaDm6xzweMlog" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_f9YqEHnMEeaDm6xzweMlog" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/IFEWithPropertyValue/In-Flight Entertainment System/In-Flight Entertainment System.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/IFEWithPropertyValue/In-Flight Entertainment System/In-Flight Entertainment System.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0">
-  <viewpointReferences id="_jSorMHhPEeeakfW4Dd3vlQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_jSorMHhPEeeakfW4Dd3vlQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/In-Flight Entertainment System/In-Flight Entertainment System.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/In-Flight Entertainment System/In-Flight Entertainment System.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_2uVOAHjqEea__MYrXGSERA">
-  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/InterfaceDelegation/InterfaceDelegation.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/InterfaceDelegation/InterfaceDelegation.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_B4YTwK56Eeey29p5ElqJMw">
-  <viewpointReferences id="_B4fogK56Eeey29p5ElqJMw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_B4fogK56Eeey29p5ElqJMw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/MelodyProject1/MelodyProject1.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/MelodyProject1/MelodyProject1.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_-AUBkJz_EeahlZzFTder8g">
-  <viewpointReferences id="_-zgZEJz_EeahlZzFTder8g" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_-zgZEJz_EeahlZzFTder8g" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/MultipleFunctions/MultipleFunctions.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/MultipleFunctions/MultipleFunctions.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_j6oJ0EVwEemR85GtHYDjcw">
-  <viewpointReferences id="_j7qEkEVwEemR85GtHYDjcw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_j7qEkEVwEemR85GtHYDjcw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/RefreshAllSubRepresentation_Empty/RefreshAllSubRepresentation_Empty.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/RefreshAllSubRepresentation_Empty/RefreshAllSubRepresentation_Empty.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_FN_ysAXEEei5J-M1z2pn0A">
-  <viewpointReferences id="_FObQgAXEEei5J-M1z2pn0A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_FObQgAXEEei5J-M1z2pn0A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/RefreshAllSubRepresentations/model.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/RefreshAllSubRepresentations/model.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_ko2-0PxHEee96NUz6nGUCg">
-  <viewpointReferences id="_kpIroPxHEee96NUz6nGUCg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_kpIroPxHEee96NUz6nGUCg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/SearchWithOptions/SearchWithOptions.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/SearchWithOptions/SearchWithOptions.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_fplYYJ82EemCksxQS2dHoQ">
-  <viewpointReferences id="_fqewQJ82EemCksxQS2dHoQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_fqewQJ82EemCksxQS2dHoQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-library/frag-library.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-library/frag-library.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_z4a4YML8Eei03oqhw1GQCA">
-  <viewpointReferences id="_z9iB4ML8Eei03oqhw1GQCA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_z9iB4ML8Eei03oqhw1GQCA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/frag-model.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/frag-model/frag-model.afm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_7HFCAML9Eei03oqhw1GQCA">
-  <viewpointReferences id="_7Hl_YML9Eei03oqhw1GQCA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_7Hl_YML9Eei03oqhw1GQCA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
   <additionalMetadata href="../frag-library/frag-library.afm#_z4a4YML8Eei03oqhw1GQCA"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/fragmentedModel/fragmentedModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/fragmentedModel/fragmentedModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="___WWULrpEeadJa2S2NItsg">
-  <viewpointReferences id="_Ag4WELrqEeadJa2S2NItsg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Ag4WELrqEeadJa2S2NItsg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/previous_version/previous_version.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/previous_version/previous_version.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_2uVOAHjqEea__MYrXGSERA">
-  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_dhQ1sIoOEeaQmcRqIfTB6w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/renameTest 1  2/renameTest 1  2.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/renameTest 1  2/renameTest 1  2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_o20nIPxrEeinZJ38EPcn1w">
-  <viewpointReferences id="_o3adAPxrEeinZJ38EPcn1w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_o3adAPxrEeinZJ38EPcn1w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.rcptt/models/renameTest/renameTest.afm
+++ b/tests/plugins/org.polarsys.capella.test.rcptt/models/renameTest/renameTest.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_gXlSMOzOEeiYm_kNG_G0NA">
-  <viewpointReferences id="_gX40MOzOEeiYm_kNG_G0NA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_gX40MOzOEeiYm_kNG_G0NA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest1/updatelinksTest1.afm
+++ b/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest1/updatelinksTest1.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Mhd-UKssEeaqI4qpUJTPsg">
-  <viewpointReferences id="_MnFeIKssEeaqI4qpUJTPsg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_MnFeIKssEeaqI4qpUJTPsg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest2/updatelinksTest2.afm
+++ b/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest2/updatelinksTest2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_-kjasKsvEeaqI4qpUJTPsg">
-  <viewpointReferences id="_-k9DUKsvEeaqI4qpUJTPsg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_-k9DUKsvEeaqI4qpUJTPsg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest2Lib/updatelinksTest2Lib.afm
+++ b/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest2Lib/updatelinksTest2Lib.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_0KqgoKstEeaqI4qpUJTPsg">
-  <viewpointReferences id="_0LKP4KstEeaqI4qpUJTPsg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_0LKP4KstEeaqI4qpUJTPsg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest3Multipart/updatelinksTest3Multipart.afm
+++ b/tests/plugins/org.polarsys.capella.test.re.updateconnections.ju/model/updatelinksTest3Multipart/updatelinksTest3Multipart.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_VbohsLVYEeaIIpcxAEb_fQ">
-  <viewpointReferences id="_Vcby8LVYEeaIIpcxAEb_fQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Vcby8LVYEeaIIpcxAEb_fQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/compliance/compliance.afm
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/compliance/compliance.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_bRhu8KHlEeeOn9U444xq2w">
-  <viewpointReferences id="_bR9z0KHlEeeOn9U444xq2w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_bR9z0KHlEeeOn9U444xq2w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/dependencies/dependencies.afm
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/dependencies/dependencies.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_KK5dANZoEeqHucK1o0_3KQ">
-  <viewpointReferences id="_KLsuQNZoEeqHucK1o0_3KQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_KLsuQNZoEeqHucK1o0_3KQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-library/frag-library.afm
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-library/frag-library.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_z4a4YML8Eei03oqhw1GQCA">
-  <viewpointReferences id="_z9iB4ML8Eei03oqhw1GQCA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_z9iB4ML8Eei03oqhw1GQCA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/frag-model.afm
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/frag-model/frag-model.afm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_7HFCAML9Eei03oqhw1GQCA">
-  <viewpointReferences id="_7Hl_YML9Eei03oqhw1GQCA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_7Hl_YML9Eei03oqhw1GQCA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
   <additionalMetadata href="../frag-library/frag-library.afm#_z4a4YML8Eei03oqhw1GQCA"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/lib-fecepl/lib-fecepl.afm
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/lib-fecepl/lib-fecepl.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_xl4YcNZOEeq0Ebq7NpA9Bg">
-  <viewpointReferences id="_xmfccNZOEeq0Ebq7NpA9Bg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_xmfccNZOEeq0Ebq7NpA9Bg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/locationPart/locationPart.afm
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/locationPart/locationPart.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_IH1ncNr6EeqfnvLjFokKNQ">
-  <viewpointReferences id="_IIuYQNr6EeqfnvLjFokKNQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_IIuYQNr6EeqfnvLjFokKNQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/re-cepl/re-cepl.afm
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/re-cepl/re-cepl.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_vJQLsNZTEeqBsPYJyvOv3Q">
-  <viewpointReferences id="_vJ32wNZTEeqBsPYJyvOv3Q" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_vJ32wNZTEeqBsPYJyvOv3Q" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/re/re.afm
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/re/re.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_r1C4wHnFEea0Df0HniJfuA">
-  <viewpointReferences id="_r1EG4HnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_r1EG4HnFEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/recs/recs.afm
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/recs/recs.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Ms4RcHnGEea0Df0HniJfuA">
-  <viewpointReferences id="_Ms5fkHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Ms5fkHnGEea0Df0HniJfuA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/whole-content-actor/whole-content-actor.afm
+++ b/tests/plugins/org.polarsys.capella.test.recrpl.ju/model/whole-content-actor/whole-content-actor.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_6CK_UOBpEemFb5JEEvZdrg">
-  <viewpointReferences id="_6Cd6QOBpEemFb5JEEvZdrg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_6Cd6QOBpEemFb5JEEvZdrg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.richtext.ju/model/RichtextTestModel/RichtextTestModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.richtext.ju/model/RichtextTestModel/RichtextTestModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_iFmRMDNYEeieBf4kJpEPiQ">
-  <viewpointReferences id="_ijUH8DNYEeieBf4kJpEPiQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_ijUH8DNYEeieBf4kJpEPiQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/model/SemanticQueries/SemanticQueries.afm
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/model/SemanticQueries/SemanticQueries.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_v4RQcH8REeaitfKJsZ85kg">
-  <viewpointReferences id="_v4TssH8REeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_v4TssH8REeaitfKJsZ85kg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/model/DiagramNavigationModel/DiagramNavigationModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/model/DiagramNavigationModel/DiagramNavigationModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_sD_doB_EEe23E9hag6DKPA">
-  <viewpointReferences id="_s5ydMB_EEe23E9hag6DKPA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_s5ydMB_EEe23E9hag6DKPA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/model/SemanticBrowserNavigation/SemanticBrowserNavigation.afm
+++ b/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/model/SemanticBrowserNavigation/SemanticBrowserNavigation.afm
@@ -4,5 +4,5 @@
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_F1_B4CzzEe2kpJxa-hdswA">
   <viewpointReferences xsi:type="metadata:ViewpointReference" id="_F2jpoCzzEe2kpJxa-hdswA"
-      vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+      vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.table/model/InterfaceTable/InterfaceTable.afm
+++ b/tests/plugins/org.polarsys.capella.test.table/model/InterfaceTable/InterfaceTable.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_8C6roPOBEeaZnfll6B5lKw">
-  <viewpointReferences id="_8C6rofOBEeaZnfll6B5lKw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_8C6rofOBEeaZnfll6B5lKw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.table/model/SF-OA/SF-OA.afm
+++ b/tests/plugins/org.polarsys.capella.test.table/model/SF-OA/SF-OA.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Stwr4POCEeaZnfll6B5lKw">
-  <viewpointReferences id="_Stwr4fOCEeaZnfll6B5lKw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Stwr4fOCEeaZnfll6B5lKw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/ActorTransition_01/ActorTransition_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/ActorTransition_01/ActorTransition_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_UHDJ8G9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_UHDJ8W9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_UHDJ8W9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/AllProjectionModels/AllProjectionModels.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/AllProjectionModels/AllProjectionModels.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_UmCzEG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_UmCzEW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_UmCzEW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/AlreadyTransitionedActor/AlreadyTransitionedActor.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/AlreadyTransitionedActor/AlreadyTransitionedActor.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_zbE14P98EeezpfsrYQ5sig">
-  <viewpointReferences id="_zfjGMP98EeezpfsrYQ5sig" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_zfjGMP98EeezpfsrYQ5sig" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_CEPL/Context_CEPL.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_CEPL/Context_CEPL.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_QTsukNcpEeq4Rv6nnvMhKA">
-  <viewpointReferences id="_QUcVcNcpEeq4Rv6nnvMhKA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_QUcVcNcpEeq4Rv6nnvMhKA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_I01/Context_I01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_I01/Context_I01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_VlrEEG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_VlrEEW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_VlrEEW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_SF01/Context_SF01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Context_SF01/Context_SF01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_WIGbsG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_WIPloG9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_WIPloG9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_IU01_01/CreateRule_IU01_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_IU01_01/CreateRule_IU01_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Wl5yAG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_Wl5yAW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Wl5yAW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_RA01_01/CreateRule_RA01_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_RA01_01/CreateRule_RA01_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_XCg1gG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_XCg1gW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_XCg1gW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_Scenario/CreateRule_Scenario.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_Scenario/CreateRule_Scenario.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_XpG7cG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_XpG7cW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_XpG7cW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/ES2ES_MoveFunction/ES2ES_MoveFunction.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/ES2ES_MoveFunction/ES2ES_MoveFunction.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_YAducAP2EeuO89rUpdYbCA">
-  <viewpointReferences id="_YA9dsAP2EeuO89rUpdYbCA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_YA9dsAP2EeuO89rUpdYbCA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/ES2ES_MoveFunctionPort/ES2ES_MoveFunctionPort.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/ES2ES_MoveFunctionPort/ES2ES_MoveFunctionPort.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_YAducAP2EeuO89rUpdYbCA">
-  <viewpointReferences id="_YA9dsAP2EeuO89rUpdYbCA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_YA9dsAP2EeuO89rUpdYbCA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/EmptySkeletonProject/EmptySkeletonProject.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/EmptySkeletonProject/EmptySkeletonProject.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_BgLwQMYJEeaR5vPRlt1ZcQ">
-  <viewpointReferences id="_BgnOEMYJEeaR5vPRlt1ZcQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_BgnOEMYJEeaR5vPRlt1ZcQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_CFE01_01/Exception_CFE01_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_CFE01_01/Exception_CFE01_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_YMII8G9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_YMII8W9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_YMII8W9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_01/Exception_FCI01_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_01/Exception_FCI01_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Yni5oG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_YnsDkG9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_YnsDkG9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_02/Exception_FCI01_02.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_02/Exception_FCI01_02.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_ZDHbUG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_ZDQlQG9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_ZDQlQG9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_03/Exception_FCI01_03.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FCI01_03/Exception_FCI01_03.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_ZeFgEG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_ZeFgEW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_ZeFgEW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FE01_01/Exception_FE01_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_FE01_01/Exception_FE01_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Z6P3oG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_Z6ZooG9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Z6ZooG9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_IP01_01/Exception_IP01_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_IP01_01/Exception_IP01_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_aW27IG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_aW27IW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_aW27IW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_ME01G_01/Exception_ME01G_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_ME01G_01/Exception_ME01G_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_aybc0G9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_aybc0W9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_aybc0W9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_OAI01_01/Exception_OAI01_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Exception_OAI01_01/Exception_OAI01_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_bNjSkG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_bNjSkW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_bNjSkW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/FunctionalChain/FunctionalChain.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/FunctionalChain/FunctionalChain.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_rNt9kE7fEemgENa2RAu1XQ">
-  <viewpointReferences id="_rPAXAE7fEemgENa2RAu1XQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_rPAXAE7fEemgENa2RAu1XQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Generation_Interface/Generation_Interface.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Generation_Interface/Generation_Interface.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_bptqIG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_bptqIW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_bptqIW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/LCPCTransition_01/LCPCTransition_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/LCPCTransition_01/LCPCTransition_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_c8tjEG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_c8tjEW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_c8tjEW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/LCPCTransition_02/LCPCTransition_02.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/LCPCTransition_02/LCPCTransition_02.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_dYITwG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_dYITwW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_dYITwW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/LaInnerLC/LaInnerLC.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/LaInnerLC/LaInnerLC.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_vwLVsNsdEeqbs-RqhTLAuQ">
-  <viewpointReferences id="_vwk-UNsdEeqbs-RqhTLAuQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_vwk-UNsdEeqbs-RqhTLAuQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Library/Library.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Library/Library.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_1fiM4EmsEeqwns4bjkbD0g">
-  <viewpointReferences id="_15Ac0EmsEeqwns4bjkbD0g" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_15Ac0EmsEeqwns4bjkbD0g" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/NonLeafAllocation/NonLeafAllocation.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/NonLeafAllocation/NonLeafAllocation.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_CPVkcAP2EeuO89rUpdYbCA">
-  <viewpointReferences id="_CP0soAP2EeuO89rUpdYbCA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_CP0soAP2EeuO89rUpdYbCA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/PLCE/PLCE.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/PLCE/PLCE.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_eJG1oO8uEemqU5fwFrKyrA">
-  <viewpointReferences id="_eKANgO8uEemqU5fwFrKyrA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_eKANgO8uEemqU5fwFrKyrA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/PartParent/PartParent.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/PartParent/PartParent.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_hy8LUNsIEeqbpdGr5lwd2w">
-  <viewpointReferences id="_hzj2YNsIEeqbpdGr5lwd2w" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_hzj2YNsIEeqbpdGr5lwd2w" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/StateEventTransition/StateEventTransition.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/StateEventTransition/StateEventTransition.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_RAAP4B3PEeejjYO-zACrJg">
-  <viewpointReferences id="_RAG9kB3PEeejjYO-zACrJg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_RAG9kB3PEeejjYO-zACrJg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/SystemTransition/SystemTransition.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/SystemTransition/SystemTransition.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_pZLFYNcBEequVfp016TkwA">
-  <viewpointReferences id="_pZ0loNcBEequVfp016TkwA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_pZ0loNcBEequVfp016TkwA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/Transition/Transition.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/Transition/Transition.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_WMqfYMJ_EemNE8q7HFcIwg">
-  <viewpointReferences id="_WNaGQMJ_EemNE8q7HFcIwg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_WNaGQMJ_EemNE8q7HFcIwg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/TwiceAllocation/TwiceAllocation.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/TwiceAllocation/TwiceAllocation.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_UOJN8AI2EeuUS6lBBU3yAg">
-  <viewpointReferences id="_VhEOYAI2EeuUS6lBBU3yAg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_VhEOYAI2EeuUS6lBBU3yAg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_FC01_01/UpdateRule_FC01_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_FC01_01/UpdateRule_FC01_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_etEtcG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_etEtcW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_etEtcW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_MEG01EI_01/UpdateRule_MEG01EI_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_MEG01EI_01/UpdateRule_MEG01EI_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_fI8KEG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_fI8KEW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_fI8KEW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_NE01_01/UpdateRule_NE01_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_NE01_01/UpdateRule_NE01_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_flGhoG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_flGhoW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_flGhoW9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_ST01_01/UpdateRule_ST01_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/UpdateRule_ST01_01/UpdateRule_ST01_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_gBHIMG9zEeaRiLEB1c1Ygg">
-  <viewpointReferences id="_gBQ5MG9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_gBQ5MG9zEeaRiLEB1c1Ygg" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/enumInPropertyPkgUnderSysEng/enumInPropertyPkgUnderSysEng.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/enumInPropertyPkgUnderSysEng/enumInPropertyPkgUnderSysEng.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_QsW6MAKUEeiGl_K6H4T7OQ">
-  <viewpointReferences id="_QszmIAKUEeiGl_K6H4T7OQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_QszmIAKUEeiGl_K6H4T7OQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/fc2fs/fc2fs.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/fc2fs/fc2fs.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_FKxawPViEeiCbvVdS-LRVA">
-  <viewpointReferences id="_FNU_gPViEeiCbvVdS-LRVA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_FNU_gPViEeiCbvVdS-LRVA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/lc-to-pc-nature-transition/transition.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/lc-to-pc-nature-transition/transition.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_yfUscGOQEeqjjs3aS6Dx4g">
-  <viewpointReferences id="_ygXOQGOQEeqjjs3aS6Dx4g" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_ygXOQGOQEeqjjs3aS6Dx4g" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/pv/pv.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/pv/pv.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_5MC5YGpZEem2CLuYvhc43Q">
-  <viewpointReferences id="_5Mb68GpZEem2CLuYvhc43Q" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_5Mb68GpZEem2CLuYvhc43Q" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/reconciliation.communicationlinks/reconciliation.communicationlinks.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/reconciliation.communicationlinks/reconciliation.communicationlinks.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_42VRkHs1EeaIfY15UCx5Ag">
-  <viewpointReferences id="_42axIHs1EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_42axIHs1EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/reconciliation.interfacelinks/reconciliation.interfacelinks.afm
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/reconciliation.interfacelinks/reconciliation.interfacelinks.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_89eGEHs1EeaIfY15UCx5Ag">
-  <viewpointReferences id="_89fUMHs1EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_89fUMHs1EeaIfY15UCx5Ag" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Bug2438/Bug2438.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Bug2438/Bug2438.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_FgV5EESpEemi06GYWbIkyQ">
-  <viewpointReferences id="_Fg55wESpEemi06GYWbIkyQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Fg55wESpEemi06GYWbIkyQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/DCON_01/DCON_01.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/DCON_01/DCON_01.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_xtdpAAS_EeeD34kA2BYAkw">
-  <viewpointReferences id="_xt8xMAS_EeeD34kA2BYAkw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_xt8xMAS_EeeD34kA2BYAkw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/DCON_03/DCON_03.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/DCON_03/DCON_03.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_d4ck0BCQEeeJ2pm718BKPA">
-  <viewpointReferences id="_d46e4BCQEeeJ2pm718BKPA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_d46e4BCQEeeJ2pm718BKPA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/I_34_Test_OK/I_34_Test_OK.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/I_34_Test_OK/I_34_Test_OK.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_nRHpkHQ-Eea1QKmGa7FbBw">
-  <viewpointReferences id="_nRO-UHQ-Eea1QKmGa7FbBw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_nRO-UHQ-Eea1QKmGa7FbBw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Library_validation12/Library_validation12.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Library_validation12/Library_validation12.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_B66TAHQ8EeaK2LnEsY_MUA">
-  <viewpointReferences id="_B6-kcHQ8EeaK2LnEsY_MUA" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_B6-kcHQ8EeaK2LnEsY_MUA" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/NoStackOverflowModel/NoStackOverflowModel.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/NoStackOverflowModel/NoStackOverflowModel.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_IG3AQHQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_IG4OYHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_IG4OYHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycle6/PackageCycle6.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycle6/PackageCycle6.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_kp0DYHQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_kp14kHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_kp14kHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest1/PackageCycleTest1.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest1/PackageCycleTest1.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_9XoHUHQ2EeaVgPeL-Ht88A">
-  <viewpointReferences id="_9XwqMHQ2EeaVgPeL-Ht88A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_9XwqMHQ2EeaVgPeL-Ht88A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest2/PackageCycleTest2.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest2/PackageCycleTest2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_BpI_0HQ3EeaVgPeL-Ht88A">
-  <viewpointReferences id="_BpMDIHQ3EeaVgPeL-Ht88A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_BpMDIHQ3EeaVgPeL-Ht88A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest3/PackageCycleTest3.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest3/PackageCycleTest3.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_D3tJIHQ3EeaVgPeL-Ht88A">
-  <viewpointReferences id="_D3u-UHQ3EeaVgPeL-Ht88A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_D3u-UHQ3EeaVgPeL-Ht88A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest4/PackageCycleTest4.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest4/PackageCycleTest4.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_GF9JYHQ3EeaVgPeL-Ht88A">
-  <viewpointReferences id="_GGIvkHQ3EeaVgPeL-Ht88A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_GGIvkHQ3EeaVgPeL-Ht88A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest5/PackageCycleTest5.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/PackageCycleTest5/PackageCycleTest5.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_IRWp8HQ3EeaVgPeL-Ht88A">
-  <viewpointReferences id="_IRYfIHQ3EeaVgPeL-Ht88A" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_IRYfIHQ3EeaVgPeL-Ht88A" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation10/Project_validation10.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation10/Project_validation10.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_qQWOEHQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_qQYDQHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_qQYDQHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation11/Project_validation11.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation11/Project_validation11.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_vU9XcHQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_vU_MoHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_vU_MoHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation12/Project_validation12.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation12/Project_validation12.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_yR0xMHQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_yR2mYHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_yR2mYHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation2/Project_validation2.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation2/Project_validation2.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_0f1g4HQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_0f3WEHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_0f3WEHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation3/Project_validation3.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation3/Project_validation3.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_3ck-0HQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_3cm0AHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_3cm0AHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation4/Project_validation4.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation4/Project_validation4.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_6TRfIHQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_6TTUUHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_6TTUUHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation5/Project_validation5.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation5/Project_validation5.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_8jvs8HQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_8jxiIHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_8jxiIHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation7/Project_validation7.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation7/Project_validation7.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_-hjdcHQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_-hlSoHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_-hlSoHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation8/Project_validation8.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation8/Project_validation8.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_BBAicHQvEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_BBCXoHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_BBCXoHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation9/Project_validation9.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation9/Project_validation9.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_DOlNQHQvEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_DOnpgHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_DOnpgHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation_12/Project_validation_12.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/Project_validation_12/Project_validation_12.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_nzkCkHQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_nzlQsHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_nzlQsHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnDesignTest/RulesOnDesignTest.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnDesignTest/RulesOnDesignTest.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_JMQsoHQvEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_JMSh0HQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_JMSh0HQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnIntegrityTest/RulesOnIntegrityTest.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnIntegrityTest/RulesOnIntegrityTest.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_NDzl8HQvEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_ND1bIHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_ND1bIHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnQualityTest/RulesOnQualityTest.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnQualityTest/RulesOnQualityTest.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Pkey8HQvEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_PkgBEHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_PkgBEHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnTransitionTest/RulesOnTransitionTest.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnTransitionTest/RulesOnTransitionTest.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_TYAH4HQvEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_TYB9EHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_TYB9EHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/exchange-item-instance-and-part-model.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/exchange-item-instance-and-part-model.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_u_rwkCgDEeuc881X317kNw">
-  <viewpointReferences id="_vAV34CgDEeuc881X317kNw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_vAV34CgDEeuc881X317kNw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/instance-role-same-name-as-represented-instance/instance-role-same-name-as-represented-instance.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/instance-role-same-name-as-represented-instance/instance-role-same-name-as-represented-instance.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_PuYNMB61Eeu0rdWZe-bqnw">
-  <viewpointReferences id="_Pv-IoB61Eeu0rdWZe-bqnw" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Pv-IoB61Eeu0rdWZe-bqnw" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testFunctionalExchangeNameConsistency/testFunctionalExchangeNameConsistency.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testFunctionalExchangeNameConsistency/testFunctionalExchangeNameConsistency.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_-OEx4CkGEeeN0Jj8LM0KEQ">
-  <viewpointReferences id="_-OGAACkGEeeN0Jj8LM0KEQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_-OGAACkGEeeN0Jj8LM0KEQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testOnRules/testOnRules.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testOnRules/testOnRules.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_Xc6u0HQvEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_Xc8kAHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_Xc8kAHQvEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testUnsynchronizedExchangeItems/testUnsynchronizedExchangeItems.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testUnsynchronizedExchangeItems/testUnsynchronizedExchangeItems.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_AZIUMCkHEeeN0Jj8LM0KEQ">
-  <viewpointReferences id="_AZJiUCkHEeeN0Jj8LM0KEQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_AZJiUCkHEeeN0Jj8LM0KEQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testUnusedExchangeItems/testUnusedExchangeItems.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/testUnusedExchangeItems/testUnusedExchangeItems.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_CcEcUCkHEeeN0Jj8LM0KEQ">
-  <viewpointReferences id="_CcFqcCkHEeeN0Jj8LM0KEQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_CcFqcCkHEeeN0Jj8LM0KEQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/validation.mergerTest/validation.mergerTest.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/validation.mergerTest/validation.mergerTest.afm
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_BEbfUHQuEeamAMxs9g9ZYQ">
-  <viewpointReferences id="_BEdUgHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.0.1"/>
+  <viewpointReferences id="_BEdUgHQuEeamAMxs9g9ZYQ" vpId="org.polarsys.capella.core.viewpoint" version="7.1.0"/>
 </metadata:Metadata>


### PR DESCRIPTION
PR to test behavior of test and ci build with capella.vp/afm/models migrated to 7.1.0

Related to #2985 