### PR TITLE
Improve ELK Integration

### DIFF
--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaElkLayoutExtension.java
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaElkLayoutExtension.java
@@ -12,6 +12,17 @@
  *******************************************************************************/
 package org.polarsys.capella.core.sirius.elk;
 
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MODES_AND_STATES_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MODE_STATE_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MSM_PSEUDOSTATE_MAPPING_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MS_INNER_PSEUDOSTATE_MAPPING_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MS_PSEUDOSTATE_MAPPING_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.PAB_COMPONENT_PORT_MAPPING_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.PAB_FUNCTIONAL_CHAIN_END_MAPPING_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.PAB_FUNCTION_PORT_ALLOCATION_MAPPING_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.PAB_FUNCTION_PORT_MAPPING_NAME;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +56,7 @@ import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
 import org.eclipse.emf.common.util.ECollections;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.DiagramEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
@@ -65,8 +77,6 @@ import org.polarsys.capella.core.data.fa.ComponentPort;
 import org.polarsys.capella.core.data.fa.FunctionInputPort;
 import org.polarsys.capella.core.data.fa.FunctionOutputPort;
 import org.polarsys.capella.core.data.fa.OrientationPortKind;
-import org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants;
-import org.polarsys.capella.core.sirius.analysis.IMappingNameConstants;
 
 /**
  * A sample implementation of {@link IELKLayoutExtension} that removes from the layout graph edges between two ports on
@@ -86,16 +96,16 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
 
     // Fix the size for all intermediate states
     private static final List<String> MASM_MAPPINGS = List.of(
-            IMappingNameConstants.MS_PSEUDOSTATE_MAPPING_NAME,
-            IMappingNameConstants.MS_INNER_PSEUDOSTATE_MAPPING_NAME,
-            IMappingNameConstants.MSM_PSEUDOSTATE_MAPPING_NAME
-    );
-    
+            MS_PSEUDOSTATE_MAPPING_NAME,
+            MS_INNER_PSEUDOSTATE_MAPPING_NAME,
+            MSM_PSEUDOSTATE_MAPPING_NAME
+            );
+
     private static final List<String> STATES_DIAGRAMS = List.of(
-        IDiagramNameConstants.MODES_AND_STATES_DIAGRAM_NAME,
-        IDiagramNameConstants.MODE_STATE_DIAGRAM_NAME
-    );
-    
+            MODES_AND_STATES_DIAGRAM_NAME,
+            MODE_STATE_DIAGRAM_NAME
+            );
+
     private record EdgeDescription(
             ElkConnectableShape source, 
             ElkConnectableShape target, 
@@ -107,7 +117,6 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
                     element.getTargets().get(0),
                     element.getContainingNode(),
                     mappedPart);
-
         }
     }
 
@@ -135,7 +144,7 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
 
         extractCircularEdges();
 
-        if (IDiagramNameConstants.PHYSICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME.equals(diagramDescription.getName())) {
+        if (PHYSICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME.equals(diagramDescription.getName())) {
             beforePabLayout();
         } else if (STATES_DIAGRAMS.contains(diagramDescription.getName())) {
             beforeStateLayout();
@@ -145,7 +154,7 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
     private void beforePabLayout() {
         // Fix the size for PAB_FunctionalChainEnd and set the label location to the east side
         List<ElkNode> nodes = getNodesWithMappingName(layoutMapping.getLayoutGraph(), 
-                List.of(IMappingNameConstants.PAB_FUNCTIONAL_CHAIN_END_MAPPING_NAME));
+                List.of(PAB_FUNCTIONAL_CHAIN_END_MAPPING_NAME));
         nodes.forEach(node -> {
             node.setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.fixed());
             // node.getLabels().forEach(label -> {
@@ -156,16 +165,15 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
         
         /** Edges reversed before layout */        
         // Reverse direction of "Port Allocation" edges
-        List<ElkEdge> edges = getEdgesWithMappingName(layoutMapping.getLayoutGraph(), List.of(IMappingNameConstants.PAB_FUNCTION_PORT_ALLOCATION_MAPPING_NAME));
-        reversedEdges.addAll(edges.stream()
+        List<ElkEdge> edges = getEdgesWithMappingName(layoutMapping.getLayoutGraph(), List.of(PAB_FUNCTION_PORT_ALLOCATION_MAPPING_NAME));
+        edges.stream()
                 // Filter invalid edges
                 .filter(edge -> !edge.getTargets().isEmpty() && !edge.isHyperedge())
                 // TODO : Is a check of Port Allocation kind is necessary ?
-                .peek(this::reverseEdge) //
-                .collect(Collectors.toList()));
+                .forEach(this::flipEdge);
 
         // Set fixed side for Input Port, Output Port and Component Port
-        List<ElkPort> fctPorts = getPortsWithMappingName(layoutMapping.getLayoutGraph(), List.of(IMappingNameConstants.PAB_FUNCTION_PORT_MAPPING_NAME));
+        List<ElkPort> fctPorts = getPortsWithMappingName(layoutMapping.getLayoutGraph(), List.of(PAB_FUNCTION_PORT_MAPPING_NAME));
         fctPorts.forEach(port -> {
             DDiagramElement dde = getDiagramElement(port);
             if (dde.getTarget() instanceof FunctionInputPort) {
@@ -175,7 +183,7 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
             } 
             // else { System.out.println("**** CASE NOT HANDLED ****"); //$NON-NLS-1$ }
         });
-        List<ElkPort> ports = getPortsWithMappingName(layoutMapping.getLayoutGraph(), List.of(IMappingNameConstants.PAB_COMPONENT_PORT_MAPPING_NAME));
+        List<ElkPort> ports = getPortsWithMappingName(layoutMapping.getLayoutGraph(), List.of(PAB_COMPONENT_PORT_MAPPING_NAME));
         ports.forEach(port -> {
             DDiagramElement dde = getDiagramElement(port);
             if (dde.getTarget() instanceof ComponentPort componentPort) {
@@ -217,10 +225,19 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
      * @throws IllegalArgumentException
      *             In case of the <code>elkEdge</code> is an hyperedge.
      */
-    protected void reverseEdge(ElkEdge elkEdge) throws IllegalArgumentException {
+    protected void flipEdge(ElkEdge elkEdge) throws IllegalArgumentException {
         if (elkEdge.isHyperedge()) {
             throw new IllegalArgumentException("The method reverseEdge does not handle \"hyperedge\"."); //$NON-NLS-1$
         }
+        if (!reversedEdges.contains(elkEdge)) {
+            changeEdgeOrientation(elkEdge);
+            reversedEdges.add(elkEdge);
+        }
+    }
+    
+    private void changeEdgeOrientation(ElkEdge elkEdge) {
+        // Do not call directly before layout.
+        // Use flipEdge instead.
         EList<ElkConnectableShape> oldSources = ECollections.newBasicEList(elkEdge.getSources());
         elkEdge.getSources().clear();
         elkEdge.getSources().addAll(elkEdge.getTargets());
@@ -248,19 +265,12 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
             end.get().setProperty(LayeredOptions.LAYERING_LAYER_CONSTRAINT, value);
         }
     }
-
     
     private void extractCircularEdges() {
         // A-Remove edges between two border nodes on the same container.
-        List<ElkEdge> edges = fetchCircularEdges(layoutMapping.getLayoutGraph()).collect(Collectors.toList());
-        edges.forEach(e -> {
-            // We remove it from the map between ELK elements and EditParts (after conserving this data in a
-            // local map).
-            extractedEdges.put(e, new EdgeDescription(e, layoutMapping.getGraphMap().remove(e)));
-
-            // And we also remove the edges from its parent and all references
-            EcoreUtil.delete(e);
-        });
+        fetchCircularEdges(layoutMapping.getLayoutGraph())
+            .collect(Collectors.toList()) // Cannot directly remove from a stream
+            .forEach(this::removeEdge);
     }
     
     @Override
@@ -270,13 +280,23 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
         }
         
         // Restore reverse edge
-        reversedEdges.forEach(it -> reverseEdge(it));
+        reversedEdges.forEach(it -> changeEdgeOrientation(it));
         reversedEdges.clear();
 
-        extractedEdges.forEach((e, n) -> restoreCircularEdge(e, n));
+        extractedEdges.forEach((e, n) -> restoreEdge(e, n));
     }
     
-    private void restoreCircularEdge(ElkEdge edge, EdgeDescription descr) {
+    private void removeEdge(ElkEdge edge) {
+        // We remove it from the map between ELK elements and EditParts (after conserving this data in a
+        // local map).
+        Object mappedPart = layoutMapping.getGraphMap().remove(edge);
+        extractedEdges.put(edge, new EdgeDescription(edge, mappedPart));
+
+        // And we also remove the edges from its parent and all references
+        EcoreUtil.delete(edge);
+    }
+    
+    private void restoreEdge(ElkEdge edge, EdgeDescription descr) {
         // Restore edge
         edge.getSources().add(descr.source);
         edge.getTargets().add(descr.target);
@@ -385,8 +405,8 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
         return streamAllNodes(elkNode, port -> containsMappingName(port, mappingNames)).collect(Collectors.toList());
     }
 
-    private List<ElkPort> getPortsWithMappingName(ElkNode elkNode, List<String> mappingNames) {
-        return streamAllPorts(elkNode, port -> containsMappingName(port, mappingNames)).collect(Collectors.toList());
+    private List<ElkPort> getPortsWithMappingName(ElkNode elkPort, List<String> mappingNames) {
+        return streamAllPorts(elkPort, port -> containsMappingName(port, mappingNames)).collect(Collectors.toList());
     }
 
     private DiagramElementMapping getElementMapping(ElkGraphElement elkElement) {
@@ -404,6 +424,11 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
         return null;
     }
     
+    private EObject getSemanticElement(ElkGraphElement elkElement) {
+        DDiagramElement diagramElement = getDiagramElement(elkElement);
+        return diagramElement != null ? diagramElement.getTarget() : null ;
+    }
+    
     private static boolean isSiriusPart(IGraphicalEditPart editPart) {
         return editPart instanceof AbstractDiagramNodeEditPart 
             || editPart instanceof AbstractDiagramBorderNodeEditPart
@@ -411,7 +436,7 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
     }
         
     /**
-     * Evaluates if a node target is a instance of semantic class.
+     * Evaluates if an element target is an instance of semantic class.
      * <p>
      * I.e. corresponding to the EditPart corresponding to the ElkNode is of the
      * expected type.
@@ -421,13 +446,8 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
      * @param expectedType of element
      * @return true if match
      */
-    private boolean isSemanticInstanceOf(ElkNode node, Class<?> expectedType) {
-        Object editPart = layoutMapping.getGraphMap().get(node);
-        if (editPart instanceof AbstractDiagramNodeEditPart nodePart
-                && nodePart.resolveSemanticElement() instanceof DDiagramElement element) {
-            return expectedType.isInstance(element.getTarget());
-        }
-        return false;
+    private boolean isSemanticInstanceOf(ElkGraphElement elkElement, Class<?> expectedType) {
+        return expectedType.isInstance(getSemanticElement(elkElement));
     }
 
     /**

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaElkLayoutExtension.java
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaElkLayoutExtension.java
@@ -12,9 +12,15 @@
  *******************************************************************************/
 package org.polarsys.capella.core.sirius.elk;
 
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.FUNCTIONAL_CHAIN_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.LOGICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.LOGICAL_DATA_FLOW_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MODES_AND_STATES_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MODE_STATE_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_DATA_FLOW_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.SYSTEM_ARCHITECTURE_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.SYSTEM_DATA_FLOW_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MSM_PSEUDOSTATE_MAPPING_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MS_INNER_PSEUDOSTATE_MAPPING_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MS_PSEUDOSTATE_MAPPING_NAME;
@@ -73,9 +79,12 @@ import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramNodeEditPart;
 import org.eclipse.sirius.ext.gmf.runtime.editparts.GraphicalHelper;
 import org.polarsys.capella.core.data.capellacommon.FinalState;
 import org.polarsys.capella.core.data.capellacommon.InitialPseudoState;
+import org.polarsys.capella.core.data.fa.AbstractFunction;
 import org.polarsys.capella.core.data.fa.ComponentPort;
 import org.polarsys.capella.core.data.fa.FunctionInputPort;
+import org.polarsys.capella.core.data.fa.FunctionKind;
 import org.polarsys.capella.core.data.fa.FunctionOutputPort;
+import org.polarsys.capella.core.data.fa.FunctionalChainInvolvement;
 import org.polarsys.capella.core.data.fa.OrientationPortKind;
 
 /**
@@ -105,6 +114,19 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
             MODES_AND_STATES_DIAGRAM_NAME,
             MODE_STATE_DIAGRAM_NAME
             );
+    
+    private static final List<String> FUNCTIONS_INCLUDED_BLANK_DIAGRAMS = List.of(
+            // Kind is ignored for OA.
+            SYSTEM_ARCHITECTURE_BLANK_DIAGRAM_NAME,
+            SYSTEM_DATA_FLOW_BLANK_DIAGRAM_NAME,
+            LOGICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME,
+            LOGICAL_DATA_FLOW_BLANK_DIAGRAM_NAME,
+            PHYSICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME,
+            PHYSICAL_DATA_FLOW_BLANK_DIAGRAM_NAME,
+            // 
+            FUNCTIONAL_CHAIN_DIAGRAM_NAME
+            );
+    
 
     private record EdgeDescription(
             ElkConnectableShape source, 
@@ -149,6 +171,21 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
         } else if (STATES_DIAGRAMS.contains(diagramDescription.getName())) {
             beforeStateLayout();
         }
+        beforeFunctionLayout(diagramDescription);
+    }
+    
+
+    private void beforeFunctionLayout(DiagramDescription diagramDescription) {
+        if (!FUNCTIONS_INCLUDED_BLANK_DIAGRAMS.contains(diagramDescription.getName())) {
+            return;
+        }
+        
+        // Set minimum size for special functions.
+        streamAllNodes(layoutMapping.getLayoutGraph(), this::isSpecialKindFunction)
+        .forEach(node-> {
+            // inspired from sizeComputationExpression
+            node.setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(40, 40));                
+        });
     }
     
     private void beforePabLayout() {
@@ -195,6 +232,16 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
             }
         });
     }
+    
+    private boolean isSpecialKindFunction(ElkGraphElement elkElement) {
+        var target = getSemanticElement(elkElement);
+        if (target instanceof FunctionalChainInvolvement involvement
+                && involvement.getInvolvedElement() instanceof AbstractFunction involvedElement) {
+            target = involvedElement;
+        }
+        return target instanceof AbstractFunction function && function.getKind() != FunctionKind.FUNCTION ;
+    }
+
     
     private static void forceSide(ElkPort port, PortSide side) {
         port.setProperty(CoreOptions.PORT_SIDE, side);

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaElkLayoutExtension.java
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaElkLayoutExtension.java
@@ -12,11 +12,17 @@
  *******************************************************************************/
 package org.polarsys.capella.core.sirius.elk;
 
+
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.CAPABILITY_REALIZATION_BLANK;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.CONTEXTUAL_CAPABILITY_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.CONTEXTUAL_MISSION_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.FUNCTIONAL_CHAIN_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.LOGICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.LOGICAL_DATA_FLOW_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MISSIONS_CAPABILITIES_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MODES_AND_STATES_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MODE_STATE_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.OPERATIONAL_CAPABILITIES_ENTITYIES_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_DATA_FLOW_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.SYSTEM_ARCHITECTURE_BLANK_DIAGRAM_NAME;
@@ -68,6 +74,7 @@ import org.eclipse.gmf.runtime.diagram.ui.editparts.DiagramEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.DDiagramElement;
+import org.eclipse.sirius.diagram.DNode;
 import org.eclipse.sirius.diagram.description.DiagramDescription;
 import org.eclipse.sirius.diagram.description.DiagramElementMapping;
 import org.eclipse.sirius.diagram.elk.ElkDiagramLayoutConnector;
@@ -79,6 +86,8 @@ import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramNodeEditPart;
 import org.eclipse.sirius.ext.gmf.runtime.editparts.GraphicalHelper;
 import org.polarsys.capella.core.data.capellacommon.FinalState;
 import org.polarsys.capella.core.data.capellacommon.InitialPseudoState;
+import org.polarsys.capella.core.data.ctx.Mission;
+import org.polarsys.capella.core.data.ctx.SystemComponent;
 import org.polarsys.capella.core.data.fa.AbstractFunction;
 import org.polarsys.capella.core.data.fa.ComponentPort;
 import org.polarsys.capella.core.data.fa.FunctionInputPort;
@@ -86,6 +95,7 @@ import org.polarsys.capella.core.data.fa.FunctionKind;
 import org.polarsys.capella.core.data.fa.FunctionOutputPort;
 import org.polarsys.capella.core.data.fa.FunctionalChainInvolvement;
 import org.polarsys.capella.core.data.fa.OrientationPortKind;
+import org.polarsys.capella.core.data.interaction.AbstractCapability;
 
 /**
  * A sample implementation of {@link IELKLayoutExtension} that removes from the layout graph edges between two ports on
@@ -127,6 +137,15 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
             FUNCTIONAL_CHAIN_DIAGRAM_NAME
             );
     
+    private static final List<String> CAPABILITIES_DIAGRAMS = List.of(
+            // Kind is ignored for OA.
+            OPERATIONAL_CAPABILITIES_ENTITYIES_BLANK_DIAGRAM_NAME,
+            CONTEXTUAL_MISSION_DIAGRAM_NAME, // reverse Mission involvement
+            CAPABILITY_REALIZATION_BLANK,
+            MISSIONS_CAPABILITIES_BLANK_DIAGRAM_NAME,
+            CONTEXTUAL_CAPABILITY_DIAGRAM_NAME
+            );
+
 
     private record EdgeDescription(
             ElkConnectableShape source, 
@@ -172,6 +191,7 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
             beforeStateLayout();
         }
         beforeFunctionLayout(diagramDescription);
+        beforeCapabilitiesLayout(diagramDescription);
     }
     
 
@@ -186,6 +206,21 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
             // inspired from sizeComputationExpression
             node.setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(40, 40));                
         });
+    }
+    
+    private void beforeCapabilitiesLayout(DiagramDescription diagramDescription) {
+        if (!CAPABILITIES_DIAGRAMS.contains(diagramDescription.getName())) {
+            return;
+        }
+
+        streamAllNodes(layoutMapping.getLayoutGraph(), it -> getDiagramElement(it) instanceof DNode)
+        .forEach(node-> {
+            var semanctic = getSemanticElement(node);
+            if (semanctic instanceof AbstractCapability
+                    || semanctic instanceof SystemComponent
+                    || semanctic instanceof Mission)
+                node.setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(70, 50));
+        });        
     }
     
     private void beforePabLayout() {

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaElkLayoutExtension.java
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaElkLayoutExtension.java
@@ -26,7 +26,9 @@ import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MI
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MODES_AND_STATES_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MODE_STATE_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.OPERATIONAL_ACTIVITY_BREAKDOWN_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.OPERATIONAL_ACTIVITY_INTERACTION_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.OPERATIONAL_CAPABILITIES_ENTITYIES_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.OPERATIONAL_ENTITY_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.OPERATIONAL_ENTITY_BREAKDOWN_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_COMPONENT_BREAKDOWN_DIAGRAM_NAME;
@@ -39,11 +41,11 @@ import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MS
 import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MS_INNER_PSEUDOSTATE_MAPPING_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MS_PSEUDOSTATE_MAPPING_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.PAB_COMPONENT_PORT_MAPPING_NAME;
-import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.PAB_FUNCTIONAL_CHAIN_END_MAPPING_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.PAB_FUNCTION_PORT_ALLOCATION_MAPPING_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.PAB_FUNCTION_PORT_MAPPING_NAME;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,6 +64,7 @@ import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.math.ElkMargin;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.NodeLabelPlacement;
 import org.eclipse.elk.core.options.PortConstraints;
 import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.core.options.SizeConstraint;
@@ -88,9 +91,8 @@ import org.eclipse.sirius.diagram.description.DiagramElementMapping;
 import org.eclipse.sirius.diagram.elk.ElkDiagramLayoutConnector;
 import org.eclipse.sirius.diagram.elk.GmfLayoutCommand;
 import org.eclipse.sirius.diagram.elk.IELKLayoutExtension;
-import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramBorderNodeEditPart;
-import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramEdgeEditPart;
-import org.eclipse.sirius.diagram.ui.edit.api.part.AbstractDiagramNodeEditPart;
+import org.eclipse.sirius.diagram.ui.edit.api.part.IAbstractDiagramNodeEditPart;
+import org.eclipse.sirius.diagram.ui.edit.api.part.IDiagramEdgeEditPart;
 import org.eclipse.sirius.ext.gmf.runtime.editparts.GraphicalHelper;
 import org.polarsys.capella.core.data.capellacommon.FinalState;
 import org.polarsys.capella.core.data.capellacommon.InitialPseudoState;
@@ -112,6 +114,10 @@ import org.polarsys.capella.core.data.interaction.AbstractCapability;
  * @author Laurent Redor
  */
 public class CapellaElkLayoutExtension implements IELKLayoutExtension {
+    
+    private static final EnumSet<NodeLabelPlacement> OUTSIDE_EAST = EnumSet.of(NodeLabelPlacement.OUTSIDE,
+            NodeLabelPlacement.V_CENTER, NodeLabelPlacement.H_RIGHT);
+
     
     /**
      * The first port on the western and eastern side is already 13 pixels away from the northern border (by the
@@ -135,6 +141,8 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
     
     private static final List<String> FUNCTIONS_INCLUDED_BLANK_DIAGRAMS = List.of(
             // Kind is ignored for OA.
+            OPERATIONAL_ACTIVITY_INTERACTION_BLANK_DIAGRAM_NAME,
+            OPERATIONAL_ENTITY_BLANK_DIAGRAM_NAME,
             SYSTEM_ARCHITECTURE_BLANK_DIAGRAM_NAME,
             SYSTEM_DATA_FLOW_BLANK_DIAGRAM_NAME,
             LOGICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME,
@@ -221,6 +229,21 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
             return;
         }
         
+        // XXX: To align all FunctionalChainEnd, they could be grouped in virtual node.
+        
+        // Fix the size for FunctionalChainEnd and set the label location to the east side as creation.
+        streamAllNodes(layoutMapping.getLayoutGraph(), node -> {
+            var mapping = getElementMapping(node);
+            return mapping != null && mapping.getName().endsWith("_FunctionalChainEnd"); //$NON-NLS-1$
+        }).forEach(node -> {
+            node.setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.fixed());
+            node.setWidth(20); // As defined in *.odesign
+            node.setHeight(20);
+            if (!node.getLabels().isEmpty()) {
+                node.getLabels().get(0).setProperty(CoreOptions.NODE_LABELS_PLACEMENT, OUTSIDE_EAST);
+            }
+        });
+        
         // Set minimum size for special functions.
         streamAllNodes(layoutMapping.getLayoutGraph(), this::isSpecialKindFunction)
         .forEach(node-> {
@@ -254,16 +277,7 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
     }
     
     private void beforePabLayout() {
-        // Fix the size for PAB_FunctionalChainEnd and set the label location to the east side
-        List<ElkNode> nodes = getNodesWithMappingName(layoutMapping.getLayoutGraph(), 
-                List.of(PAB_FUNCTIONAL_CHAIN_END_MAPPING_NAME));
-        nodes.forEach(node -> {
-            node.setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.fixed());
-            // node.getLabels().forEach(label -> {
-            // label.setProperty(CoreOptions.NODE_LABELS_PLACEMENT, EnumSet.of(NodeLabelPlacement.OUTSIDE,
-            // NodeLabelPlacement.V_CENTER, NodeLabelPlacement.H_RIGHT));
-            // });
-        });
+
         
         /** Edges reversed before layout */        
         // Reverse direction of "Port Allocation" edges
@@ -542,9 +556,8 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
     }
     
     private static boolean isSiriusPart(IGraphicalEditPart editPart) {
-        return editPart instanceof AbstractDiagramNodeEditPart 
-            || editPart instanceof AbstractDiagramBorderNodeEditPart
-            || editPart instanceof AbstractDiagramEdgeEditPart;
+        return editPart instanceof IAbstractDiagramNodeEditPart 
+            || editPart instanceof IDiagramEdgeEditPart;
     }
         
     /**

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaElkLayoutExtension.java
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaElkLayoutExtension.java
@@ -14,19 +14,27 @@ package org.polarsys.capella.core.sirius.elk;
 
 
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.CAPABILITY_REALIZATION_BLANK;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.CONFIGURATION_ITEMS_BREAKDOWN_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.CONTEXTUAL_CAPABILITY_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.CONTEXTUAL_MISSION_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.FUNCTIONAL_CHAIN_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.LOGICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.LOGICAL_COMPONENT_BREAKDOWN_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.LOGICAL_DATA_FLOW_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.LOGICAL_FUNCTION_BREAKDOWN_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MISSIONS_CAPABILITIES_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MODES_AND_STATES_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.MODE_STATE_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.OPERATIONAL_ACTIVITY_BREAKDOWN_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.OPERATIONAL_CAPABILITIES_ENTITYIES_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.OPERATIONAL_ENTITY_BREAKDOWN_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_COMPONENT_BREAKDOWN_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_DATA_FLOW_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_FUNCTION_BREAKDOWN_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.SYSTEM_ARCHITECTURE_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.SYSTEM_DATA_FLOW_BLANK_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.SYSTEM_FUNCTION_BREAKDOWN_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MSM_PSEUDOSTATE_MAPPING_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MS_INNER_PSEUDOSTATE_MAPPING_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IMappingNameConstants.MS_PSEUDOSTATE_MAPPING_NAME;
@@ -146,6 +154,18 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
             CONTEXTUAL_CAPABILITY_DIAGRAM_NAME
             );
 
+    private static final Map<String, String> BREAKDOWN_DIAGRAM_FEATURES = Map.of(
+            // All containment relationships.
+            SYSTEM_FUNCTION_BREAKDOWN_DIAGRAM_NAME, "SFB_SystemFunction_subFunctions", //$NON-NLS-1$
+            CONFIGURATION_ITEMS_BREAKDOWN_DIAGRAM_NAME, "CIBD_ConfigurationItem_subComponents", //$NON-NLS-1$
+            LOGICAL_COMPONENT_BREAKDOWN_DIAGRAM_NAME, "LCB_LogicalComponent_subComponents", //$NON-NLS-1$
+            LOGICAL_FUNCTION_BREAKDOWN_DIAGRAM_NAME, "LFB_LogicalFunction_subFunctions", //$NON-NLS-1$
+            OPERATIONAL_ACTIVITY_BREAKDOWN_DIAGRAM_NAME, "OAB_OperationalActivity_subFunctions", //$NON-NLS-1$
+            OPERATIONAL_ENTITY_BREAKDOWN_DIAGRAM_NAME, "containedIn Mapping", //$NON-NLS-1$
+            PHYSICAL_COMPONENT_BREAKDOWN_DIAGRAM_NAME, "PCB_PhysicalComponent_subComponents", //$NON-NLS-1$
+            PHYSICAL_FUNCTION_BREAKDOWN_DIAGRAM_NAME, "PFB_PhysicalFunction_subFunctions" //$NON-NLS-1$
+    );
+    
 
     private record EdgeDescription(
             ElkConnectableShape source, 
@@ -192,6 +212,7 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
         }
         beforeFunctionLayout(diagramDescription);
         beforeCapabilitiesLayout(diagramDescription);
+        beforeBreakdown(diagramDescription);
     }
     
 
@@ -221,6 +242,15 @@ public class CapellaElkLayoutExtension implements IELKLayoutExtension {
                     || semanctic instanceof Mission)
                 node.setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(70, 50));
         });        
+    }
+    
+    private void beforeBreakdown(DiagramDescription diagramDescription) {
+        String treeMapping = BREAKDOWN_DIAGRAM_FEATURES.get(diagramDescription.getName());
+        if (treeMapping != null) {
+            streamAllEdges(layoutMapping.getLayoutGraph(), 
+                    edge -> treeMapping.equals(getElementMapping(edge).getName()))
+            .forEach(this::flipEdge);
+        }
     }
     
     private void beforePabLayout() {

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaGmfLayoutProvider.java
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaGmfLayoutProvider.java
@@ -50,7 +50,7 @@ import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PH
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.PHYSICAL_PATH_DESCRIPTION_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.SYSTEM_ARCHITECTURE_BLANK_DIAGRAM_NAME;
 import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.SYSTEM_DATA_FLOW_BLANK_DIAGRAM_NAME;
-import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.SYSTEM_FUNCTION_BREAKDOWN_DIAGRAM_NAME;
+import static org.polarsys.capella.core.sirius.analysis.IDiagramNameConstants.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -117,6 +117,8 @@ public class CapellaGmfLayoutProvider extends DefaultLayoutProvider {
             // 3- Improvement (initial in first)
 
             // Capabilities diagrams
+            CONTEXTUAL_MISSION_DIAGRAM_NAME,
+            CONTEXTUAL_CAPABILITY_DIAGRAM_NAME,
             CONTEXTUAL_CAPABILITY_REALIZATION_INVOLVEMENT, // Not tested (no such diagram in IFE sample)
             CAPABILITY_REALIZATION_BLANK, // Not tested (no such diagram in IFE sample)
             MISSIONS_BLANK_DIAGRAM_NAME, // Not tested (no such diagram in IFE sample)

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaGmfLayoutProvider.java
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaGmfLayoutProvider.java
@@ -126,13 +126,14 @@ public class CapellaGmfLayoutProvider extends DefaultLayoutProvider {
                                                                     // Services"
             // 1- Specific size for "Mission", "Capability" and "Actor"
             // 2- Improvement : Top down layout is better
-            MISSIONS_CAPABILITIES_BLANK_DIAGRAM_NAME, // KO tested on "[MCB] All Missions and Capabilities"
+            MISSIONS_CAPABILITIES_BLANK_DIAGRAM_NAME, // OK tested on "[MCB] All Missions and Capabilities"
             // 1- Specific size for "Mission", "Capability" and "Actor"
             CAPABILITY_REALIZATION_REFINEMENT, // Not tested (no such diagram in IFE sample)
             OPERATIONAL_CAPABILITIES_ENTITYIES_BLANK_DIAGRAM_NAME, // KO tested on "[OCB] Operational Capabilities"
             // 1- Specific size for "Entity", "Capability" and "Actor"
             // 2- Improvement : Same size for all actors
             CONTEXTUAL_OC_DIAGRAM_NAME, // Not tested (no such diagram in IFE sample)
+            
 
             // Data flow blank diagrams
             OPERATIONAL_ACTIVITY_INTERACTION_BLANK_DIAGRAM_NAME, // tested
@@ -151,32 +152,24 @@ public class CapellaGmfLayoutProvider extends DefaultLayoutProvider {
             LOGICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME, // OK (tested on IFE sample 
                                 // "[LAB] [BUILD] All Components, Functions, CEs, FEs")
             PHYSICAL_ARCHITECTURE_BLANK_DIAGRAM_NAME, // tested
-            OPERATIONAL_ROLE_BLANK_DIAGRAM_NAME // Not tested (no such diagram in IFE sample)
-    );
+            OPERATIONAL_ROLE_BLANK_DIAGRAM_NAME, // Not tested (no such diagram in IFE sample)
+
+            // TODO (sequence flow not a tree)
+            FUNCTIONAL_CHAIN_DIAGRAM_NAME,
+            OPERATIONAL_PROCESS_DESCRIPTION_DIAGRAM_NAME
+            );
 
     /** List of diagrams using Mr Tree algorithm. */
     private static final List<String> MR_TREE_DIAGRAM_DESCRIPTION_NAMES = List.of(
             // Breakdown diagrams
-            SYSTEM_FUNCTION_BREAKDOWN_DIAGRAM_NAME, // KO wrong children order
-            CONTEXTUAL_MISSION_DIAGRAM_NAME, // KO (tested on "[CM] Provide Entertainment Solutions" of IFE sample)
-            // 1- The space between children does not consider label outside of the node
-            FUNCTIONAL_CHAIN_DIAGRAM_NAME, // KO (tested on "[LFCD] Broadcast Audio Announcement" of IFE sample)
-            // 1- wrong location of edge's labels
-            // 2- space for label on edge is too small
-            CONFIGURATION_ITEMS_BREAKDOWN_DIAGRAM_NAME, // Not tested (no such diagram in IFE sample)
-            LOGICAL_COMPONENT_BREAKDOWN_DIAGRAM_NAME, // KO (tested on "[LCBD] Architecture Drivers" of IFE sample)
-            // 1 - wrong children order
-            LOGICAL_FUNCTION_BREAKDOWN_DIAGRAM_NAME, // KO (tested on "[LFBD] All Functions" of IFE sample)
-                                                                     // wrong children order
-            OPERATIONAL_ENTITY_BREAKDOWN_DIAGRAM_NAME, // KO wrong children order
-            OPERATIONAL_ACTIVITY_BREAKDOWN_DIAGRAM_NAME, // KO wrong children order
-            PHYSICAL_FUNCTION_BREAKDOWN_DIAGRAM_NAME, // KO wrong children order and strange result on
-                                                                     // "[PFBD] All Physical Functions"
-            PHYSICAL_COMPONENT_BREAKDOWN_DIAGRAM_NAME, // KO (tested on "[PCBD] Behavioural Components")
-            OPERATIONAL_PROCESS_DESCRIPTION_DIAGRAM_NAME // KO
-            // 1- wrong location of edge's labels
-            // 2- space for label on edge is too small
-            // 3- Maybe a layered diagram desc would be better
+            OPERATIONAL_ENTITY_BREAKDOWN_DIAGRAM_NAME,
+            OPERATIONAL_ACTIVITY_BREAKDOWN_DIAGRAM_NAME,
+            SYSTEM_FUNCTION_BREAKDOWN_DIAGRAM_NAME,
+            LOGICAL_COMPONENT_BREAKDOWN_DIAGRAM_NAME,
+            LOGICAL_FUNCTION_BREAKDOWN_DIAGRAM_NAME,
+            PHYSICAL_FUNCTION_BREAKDOWN_DIAGRAM_NAME,
+            PHYSICAL_COMPONENT_BREAKDOWN_DIAGRAM_NAME,
+            CONFIGURATION_ITEMS_BREAKDOWN_DIAGRAM_NAME
     );
 
     /** List of diagrams using Layered algorithm. */

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaSiriusLayoutProvider.java
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaSiriusLayoutProvider.java
@@ -78,7 +78,12 @@ public class CapellaSiriusLayoutProvider extends GenericLayoutProvider {
     }
 
     static CustomLayoutConfiguration createMrTreeConfiguration() {
-        return createConfiguration(MrTreeOptions.ALGORITHM_ID);
+        CustomLayoutConfiguration result = createConfiguration(MrTreeOptions.ALGORITHM_ID);
+        // Spacing.node_node: default (20) is cumbersome.
+        addDoubleOption(result, CoreOptions.SPACING_NODE_NODE, TARGET_PARENT, 40);
+        // Half spacing.edgeNode : Horizontal edge will be centered.
+        addDoubleOption(result, CoreOptions.SPACING_EDGE_NODE, TARGET_PARENT, 20);
+        return result;
     }
 
     static CustomLayoutConfiguration createDotConfiguration() {

--- a/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaSiriusLayoutProvider.java
+++ b/ext/elk/plugins/org.polarsys.capella.core.sirius.elk/src/org/polarsys/capella/core/sirius/elk/CapellaSiriusLayoutProvider.java
@@ -29,6 +29,7 @@ import org.eclipse.elk.core.options.SizeConstraint;
 import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.sirius.diagram.DDiagram;
+import org.eclipse.sirius.diagram.description.BooleanLayoutOption;
 import org.eclipse.sirius.diagram.description.CustomLayoutConfiguration;
 import org.eclipse.sirius.diagram.description.DescriptionFactory;
 import org.eclipse.sirius.diagram.description.DoubleLayoutOption;
@@ -121,7 +122,8 @@ public class CapellaSiriusLayoutProvider extends GenericLayoutProvider {
         // * and the above space between 2 edges
         addDoubleOption(result, CoreOptions.SPACING_PORT_PORT, TARGET_PARENT, 13);
         // Align firstly the upper element and then the lower (ditto for left and then right)
-        addEnumOption(result, LayeredOptions.NODE_PLACEMENT_BK_FIXED_ALIGNMENT, TARGET_PARENT, FixedAlignment.RIGHTDOWN);
+        addEnumOption(result, LayeredOptions.NODE_PLACEMENT_BK_FIXED_ALIGNMENT, TARGET_PARENT, FixedAlignment.BALANCED);
+        addBooleanOption(result, LayeredOptions.MERGE_EDGES, TARGET_PARENT, true);
         // Change the direction of the layout
         addEnumOption(result, CoreOptions.DIRECTION, TARGET_PARENT, horizontal ? Direction.RIGHT : Direction.DOWN);
         // Reduce the space between a label and its edge to 0 pixel (default value is 2)
@@ -142,6 +144,7 @@ public class CapellaSiriusLayoutProvider extends GenericLayoutProvider {
     /**
      * Generic method to finalize a {@link LayoutOption} initialization and to add it to the current container.
      * 
+     * @param <O> type of option
      * @param container
      *            The container to set this option on.
      * @param id
@@ -152,13 +155,30 @@ public class CapellaSiriusLayoutProvider extends GenericLayoutProvider {
      *            The concerned option
      * @return the {@code option) for convenience
      */
-    protected static LayoutOption addLayoutOption(CustomLayoutConfiguration container, IProperty<?> id, List<LayoutOptionTarget> targets, LayoutOption option) {
+    protected static <O extends LayoutOption> O addLayoutOption(CustomLayoutConfiguration container, IProperty<?> id, List<LayoutOptionTarget> targets, O option) {
         option.setId(id.getId());
         option.getTargets().addAll(targets);
         container.getLayoutOptions().add(option);
         return option;
     }
 
+    /**
+     * Create a new {@link EnumLayoutOption}.
+     * 
+     * @param id
+     *            The id of the option
+     * @param targets
+     *            The targets of this option (as it is defined in ELK documentation)
+     * @param name
+     *            The name of the Enum value
+     * @return the new option
+     */
+    protected static BooleanLayoutOption addBooleanOption(CustomLayoutConfiguration container, IProperty<Boolean> id, List<LayoutOptionTarget> targets, boolean value) {
+        BooleanLayoutOption result = LFCT.createBooleanLayoutOption();
+        result.setValue(value);
+        return addLayoutOption(container, id, targets, result);
+    }
+    
     /**
      * Create a new {@link DoubleLayoutOption}.
      * 
@@ -170,7 +190,7 @@ public class CapellaSiriusLayoutProvider extends GenericLayoutProvider {
      *            The value of this option
      * @return the new option
      */
-    protected static LayoutOption addDoubleOption(CustomLayoutConfiguration container, IProperty<?> id, List<LayoutOptionTarget> targets, double value) {
+    protected static DoubleLayoutOption addDoubleOption(CustomLayoutConfiguration container, IProperty<?> id, List<LayoutOptionTarget> targets, double value) {
         DoubleLayoutOption result = LFCT.createDoubleLayoutOption();
         result.setValue(value);
         return addLayoutOption(container, id, targets, result);
@@ -187,7 +207,7 @@ public class CapellaSiriusLayoutProvider extends GenericLayoutProvider {
      *            The value of this option
      * @return the new option
      */
-    protected static LayoutOption addIntegerOption(CustomLayoutConfiguration container, IProperty<?> id, List<LayoutOptionTarget> targets, int value) {
+    protected static IntegerLayoutOption addIntegerOption(CustomLayoutConfiguration container, IProperty<?> id, List<LayoutOptionTarget> targets, int value) {
         IntegerLayoutOption result = LFCT.createIntegerLayoutOption();
         result.setValue(value);
         return addLayoutOption(container, id, targets, result);
@@ -204,7 +224,7 @@ public class CapellaSiriusLayoutProvider extends GenericLayoutProvider {
      *            The name of the Enum value
      * @return the new option
      */
-    protected static <T extends Enum<?>> LayoutOption addEnumOption(CustomLayoutConfiguration container, IProperty<T> id, List<LayoutOptionTarget> targets, T value) {
+    protected static <T extends Enum<?>> EnumLayoutOption addEnumOption(CustomLayoutConfiguration container, IProperty<T> id, List<LayoutOptionTarget> targets, T value) {
         EnumLayoutOption result = LFCT.createEnumLayoutOption();
         EnumLayoutValue enumLayoutValue = LFCT.createEnumLayoutValue();
         enumLayoutValue.setName(value.name());
@@ -212,7 +232,7 @@ public class CapellaSiriusLayoutProvider extends GenericLayoutProvider {
         return addLayoutOption(container, id, targets, result);
     }
    
-    /**
+   /**
      * Create a new {@link EnumSetLayoutOption}.
      * 
      * @param id
@@ -223,7 +243,7 @@ public class CapellaSiriusLayoutProvider extends GenericLayoutProvider {
      *            The targets of this option (as it is defined in ELK documentation)
      * @return the new option
      */
-    protected static <T extends Enum<?>> LayoutOption addEnumsOption(CustomLayoutConfiguration container, IProperty<? extends EnumSet<? extends T>> id, List<LayoutOptionTarget> targets, @SuppressWarnings("unchecked") T... values) {
+    protected static <T extends Enum<?>> EnumSetLayoutOption addEnumsOption(CustomLayoutConfiguration container, IProperty<? extends EnumSet<? extends T>> id, List<LayoutOptionTarget> targets, @SuppressWarnings("unchecked") T... values) {
         EnumSetLayoutOption result = LFCT.createEnumSetLayoutOption();
         for (T value : values) {
             EnumLayoutValue enumLayoutValue = LFCT.createEnumLayoutValue();


### PR DESCRIPTION
This PR improves configuration of ELK to layout diagram on "Arrange" action.

It groups several issues as they all concerns the same set of classes:
#3006: "special" functions (with icon) have now a minimal size in all blank diagram, same as creation.
#3007: mission, capability (and similar) have now a minimal size, same as creation.
#3008: Edge of breakdown diagram have now an adequate direction for ELK. ELK can create the tree properly.
#3009: OPD, SFBD and similar use now ELK layered layout.
#3014: Placement of node are centered to have more regularity in layout.
#3015: Functional chain node have all the same readable size after layout.